### PR TITLE
expose hook assignment method in eppo client interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -309,49 +309,39 @@ describe('EppoClient E2E test', () => {
     describe('onPreAssignment', () => {
       it('called with subject ID', () => {
         const mockHooks = td.object<IAssignmentHooks>();
-        client.getAssignmentWithHooks('subject-identifer', experimentName, {}, mockHooks);
+        client.getAssignmentWithHooks('subject-identifer', experimentName, mockHooks);
         expect(td.explain(mockHooks.onPreAssignment).callCount).toEqual(1);
         expect(td.explain(mockHooks.onPreAssignment).calls[0].args[0]).toEqual('subject-identifer');
       });
 
       it('overrides returned assignment', async () => {
-        const variation = await client.getAssignmentWithHooks(
-          'subject-identifer',
-          experimentName,
-          {},
-          {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            onPreAssignment(subject: string): Promise<string> {
-              return Promise.resolve('my-overridden-variation');
-            },
-
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            onPostAssignment(variation: string): Promise<void> {
-              return Promise.resolve();
-            },
+        const variation = await client.getAssignmentWithHooks('subject-identifer', experimentName, {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          onPreAssignment(subject: string): Promise<string> {
+            return Promise.resolve('my-overridden-variation');
           },
-        );
+
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          onPostAssignment(variation: string): Promise<void> {
+            return Promise.resolve();
+          },
+        });
 
         expect(variation).toEqual('my-overridden-variation');
       });
 
       it('uses regular assignment logic if onPreAssignment returns null', async () => {
-        const variation = await client.getAssignmentWithHooks(
-          'subject-identifer',
-          experimentName,
-          {},
-          {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            onPreAssignment(subject: string): Promise<string | null> {
-              return Promise.resolve(null);
-            },
-
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            onPostAssignment(variation: string): Promise<void> {
-              return Promise.resolve();
-            },
+        const variation = await client.getAssignmentWithHooks('subject-identifer', experimentName, {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          onPreAssignment(subject: string): Promise<string | null> {
+            return Promise.resolve(null);
           },
-        );
+
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          onPostAssignment(variation: string): Promise<void> {
+            return Promise.resolve();
+          },
+        });
 
         expect(variation).not.toEqual(null);
       });
@@ -363,7 +353,6 @@ describe('EppoClient E2E test', () => {
         const variation = await client.getAssignmentWithHooks(
           'subject-identifer',
           experimentName,
-          {},
           mockHooks,
         );
         expect(td.explain(mockHooks.onPostAssignment).callCount).toEqual(1);

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -31,6 +31,25 @@ export interface IEppoClient {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     subjectAttributes?: Record<string, any>,
   ): string;
+
+  /**
+   * Asynchronously maps a subject to a variation for a given experiment, with pre and post assignment hooks
+   *
+   * @param subjectKey an identifier of the experiment subject, for example a user ID.
+   * @param experimentKey experiment identifier
+   * @param assignmentHooks interface for pre and post assignment hooks
+   * @param subjectAttributes optional attributes associated with the subject, for example name and email.
+   * The subject attributes are used for evaluating any targeting rules tied to the experiment.
+   * @returns a variation value if the subject is part of the experiment sample, otherwise null
+   * @public
+   */
+  getAssignmentWithHooks(
+    subjectKey: string,
+    experimentKey: string,
+    assignmentHooks: IAssignmentHooks,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    subjectAttributes?: Record<string, any>,
+  ): Promise<string>;
 }
 
 export default class EppoClient implements IEppoClient {
@@ -77,8 +96,8 @@ export default class EppoClient implements IEppoClient {
   async getAssignmentWithHooks(
     subjectKey: string,
     experimentKey: string,
-    subjectAttributes = {},
     assignmentHooks: IAssignmentHooks,
+    subjectAttributes = {},
   ): Promise<string> {
     let assignment = await assignmentHooks?.onPreAssignment(subjectKey);
     if (assignment == null) {


### PR DESCRIPTION
## Description
[//]: # (Describe your changes in detail)
Expose the `getAssignmentWithHooks` method in the `IEppoClient` interface. Fix ordering of parameters to have optional params last. 