### PR TITLE
add typings and module declaration (FF-863)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,13 @@
   "files": [
     "/dist"
   ],
-  "types": "./typings.d.ts",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "lint": "eslint '**/*.{ts,tsx}' --cache",
     "lint:fix": "eslint --fix '**/*.{ts,tsx}' --cache",

--- a/package.json
+++ b/package.json
@@ -6,17 +6,16 @@
   "files": [
     "/dist"
   ],
-  "typings": "dist/js-client-sdk-common.d.ts",
+  "types": "./typings.d.ts",
   "scripts": {
     "lint": "eslint '**/*.{ts,tsx}' --cache",
     "lint:fix": "eslint --fix '**/*.{ts,tsx}' --cache",
     "lint:fix-pre-commit": "eslint -c .eslintrc.pre-commit.js --fix '**/*.{ts,tsx}' --no-eslintrc --cache",
     "prepare": "make prepare",
-    "pre-commit": "lint-staged && tsc && yarn docs",
+    "pre-commit": "lint-staged && tsc",
     "typecheck": "tsc",
     "test": "yarn test:unit",
-    "test:unit": "NODE_ENV=test jest '.*\\.spec\\.ts'",
-    "docs": "api-documenter markdown -i ./temp -o ./docs"
+    "test:unit": "NODE_ENV=test jest '.*\\.spec\\.ts'"
   },
   "jsdelivr": "dist/eppo-sdk.js",
   "repository": {

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,0 +1,1 @@
+declare module 'js-client-sdk-common' {}

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,1 +1,0 @@
-declare module 'js-client-sdk-common' {}


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Importing this module as a dependency into `js-client-sdk` was failing. I found that a recent change (https://github.com/Eppo-exp/js-client-sdk-common/commit/4fdcce52bfcc83a765785b6bd0444acd8d787a74) from using a combination of npm & yarn to just yarn led to the primary typings file not longer being compiled into the `dist` directory:

```
➜  js-client-sdk-common git:(heads/tags/v1.2.2) ✗ yarn
➜  js-client-sdk-common git:(heads/tags/v1.2.2) ✗ ls -la dist/js-client-sdk-common.d.ts
-rw-r--r--  1 leo  staff  6901 Aug 30 11:22 dist/js-client-sdk-common.d.ts

➜  js-client-sdk-common git:(main) yarn
➜  js-client-sdk-common git:(main) ls -la dist/js-client-sdk-common.d.ts
ls: dist/js-client-sdk-common.d.ts: No such file or directory
```

https://linear.app/eppo/issue/FF-863/js-client-sdk-common-v130-cannot-be-added-as-a-dependency

## Description
[//]: # (Describe your changes in detail)

I wasn't exactly sure the root cause of the issue but modeled the solution in this PR on the launchdarkly repository:

https://github.com/Eppo-exp/js-client-sdk-common/commit/4fdcce52bfcc83a765785b6bd0444acd8d787a74#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519

There is a `typings.d.ts` file present with a module declaration. Some research on stackoverflow made me believe that just declaring the module would be sufficient to fix this issue.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

compiled the common library

```
➜  js-client-sdk-common git:(lr/add-typings2) yarn
...
webpack 5.73.0 compiled successfully in 1096 ms
✨  Done in 8.89s.
```

linked it locally to `js-client-sdk`:

```
➜  js-client-sdk git:(update-common-sync-hooks) ✗ git diff
diff --git a/package.json b/package.json
index f3499a6..b82e6ae 100644
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "^1.3.0",
+    "@eppo/js-client-sdk-common": "../js-client-sdk-common/dist",
     "axios": "^0.27.2",
     "md5": "^2.3.0"
   }
diff --git a/yarn.lock b/yarn.lock
index 344eb51..b47dd70 100644
--- a/yarn.lock
+++ b/yarn.lock
@@ -289,13 +289,8 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==

-"@eppo/js-client-sdk-common@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-1.3.0.tgz#abbc926ad31a8d96501ee443077f60138316a59e"
-  integrity sha512-OYbonzTW/uYgFBt6Ac03NEu2JviIiLQainP/wKH9L6GT/cGAxqDWV5+6wkqsk8r0sDRia2FI2a3jFp+1+DcnRA==
-  dependencies:
-    axios "^0.27.2"
-    md5 "^2.3.0"
+"@eppo/js-client-sdk-common@../js-client-sdk-common/dist":
+  version "0.0.0"

 "@eslint/eslintrc@^1.3.0":
   version "1.3.0"
```

compiled `js-client-sdk`

```
➜  js-client-sdk git:(update-common-sync-hooks) ✗ yarn
yarn install v1.22.19
...
✨  Done in 12.39s.
```

observed that it appeared to be imported normally within vscode

<img width="1226" alt="Screenshot 2023-08-30 at 3 29 36 PM" src="https://github.com/Eppo-exp/js-client-sdk-common/assets/57361/e8fd23cf-5a29-4d25-b61b-9211cbd026c9">

<img width="1226" alt="Screenshot 2023-08-30 at 3 29 27 PM" src="https://github.com/Eppo-exp/js-client-sdk-common/assets/57361/c8639a23-8ea0-4c19-ab18-f62ea1fc9f3a">

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
