### PR TITLE
Sameeran/ff 924 update js sdk common with allocation key

### DIFF
--- a/src/assignment-hooks.ts
+++ b/src/assignment-hooks.ts
@@ -14,10 +14,7 @@ export interface IAssignmentHooks {
    * then the subject will be assigned with the default assignment logic.
    * @public
    */
-  onPreAssignment(
-    flagKey: string,
-    subject: string
-  ): EppoValue | null;
+  onPreAssignment(flagKey: string, subject: string): EppoValue | null;
 
   /**
    * Invoked after a subject is assigned. Useful for any post assignment logic needed which is specific
@@ -32,6 +29,6 @@ export interface IAssignmentHooks {
     flagKey: string,
     subject: string,
     variation: EppoValue | null,
-    allocationKey?: string | null
+    allocationKey?: string | null,
   ): void;
 }

--- a/src/assignment-hooks.ts
+++ b/src/assignment-hooks.ts
@@ -25,5 +25,5 @@ export interface IAssignmentHooks {
    * @param allocationKey key of the allocation being used for assignment
    * @public
    */
-  onPostAssignment(flagKey: string, subject: string, variation: EppoValue | null, allocationKey?: string): void;
+  onPostAssignment(flagKey: string, subject: string, variation: EppoValue | null, allocationKey?: string | null): void;
 }

--- a/src/assignment-hooks.ts
+++ b/src/assignment-hooks.ts
@@ -8,21 +8,22 @@ export interface IAssignmentHooks {
   /**
    * Invoked before a subject is assigned to an experiment variation.
    *
-   * @param experimentKey key of the experiment being assigned
+   * @param flagKey key of the feature flag being used for assignment
    * @param subject id of subject being assigned
    * @returns variation to override for the given subject. If null is returned,
    * then the subject will be assigned with the default assignment logic.
    * @public
    */
-  onPreAssignment(experimentKey: string, subject: string): EppoValue | null;
+  onPreAssignment(flagKey: string, subject: string): EppoValue | null;
 
   /**
    * Invoked after a subject is assigned. Useful for any post assignment logic needed which is specific
-   * to an experiment/flag. Do not use this for logging assignments - use IAssignmentLogger instead.
-   * @param experimentKey key of the experiment being assigned
+   * to a flag or allocation. Do not use this for logging assignments - use IAssignmentLogger instead.
+   * @param flagKey key of the feature flag being used for assignment
    * @param subject id of subject being assigned
    * @param variation the assigned variation
+   * @param allocationKey key of the allocation being used for assignment
    * @public
    */
-  onPostAssignment(experimentKey: string, subject: string, variation: EppoValue | null): void;
+  onPostAssignment(flagKey: string, subject: string, variation: EppoValue | null, allocationKey?: string): void;
 }

--- a/src/assignment-hooks.ts
+++ b/src/assignment-hooks.ts
@@ -14,7 +14,10 @@ export interface IAssignmentHooks {
    * then the subject will be assigned with the default assignment logic.
    * @public
    */
-  onPreAssignment(flagKey: string, subject: string): EppoValue | null;
+  onPreAssignment(
+    flagKey: string,
+    subject: string
+  ): EppoValue | null;
 
   /**
    * Invoked after a subject is assigned. Useful for any post assignment logic needed which is specific
@@ -25,5 +28,10 @@ export interface IAssignmentHooks {
    * @param allocationKey key of the allocation being used for assignment
    * @public
    */
-  onPostAssignment(flagKey: string, subject: string, variation: EppoValue | null, allocationKey?: string | null): void;
+  onPostAssignment(
+    flagKey: string,
+    subject: string,
+    variation: EppoValue | null,
+    allocationKey?: string | null
+  ): void;
 }

--- a/src/assignment-logger.ts
+++ b/src/assignment-logger.ts
@@ -4,9 +4,19 @@
  */
 export interface IAssignmentEvent {
   /**
+   * An Eppo allocation key
+   */
+  allocation: string;
+
+  /**
    * An Eppo experiment key
    */
   experiment: string;
+
+  /**
+   * An Eppo feature flag key
+   */
+  featureFlag: string;
 
   /**
    * The assigned variation

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -402,9 +402,9 @@ describe('EppoClient E2E test', () => {
 
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             onPostAssignment(
-              experimentKey: string,
-              subject: string,
-              variation: EppoValue | null,
+              experimentKey: string, // eslint-disable-line @typescript-eslint/no-unused-vars
+              subject: string, // eslint-disable-line @typescript-eslint/no-unused-vars
+              variation: EppoValue | null, // eslint-disable-line @typescript-eslint/no-unused-vars
             ): void {
               // no-op
             },
@@ -425,11 +425,10 @@ describe('EppoClient E2E test', () => {
               return null;
             },
 
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             onPostAssignment(
-              experimentKey: string,
-              subject: string,
-              variation: EppoValue | null,
+              experimentKey: string, // eslint-disable-line @typescript-eslint/no-unused-vars
+              subject: string, // eslint-disable-line @typescript-eslint/no-unused-vars
+              variation: EppoValue | null, // eslint-disable-line @typescript-eslint/no-unused-vars
             ): void {
               // no-op
             },

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -80,10 +80,10 @@ describe('EppoClient E2E test', () => {
     mock.teardown();
   });
 
-  const experimentName = 'mock-experiment';
+  const flagKey = 'mock-experiment';
 
   const mockExperimentConfig = {
-    name: experimentName,
+    name: flagKey,
     enabled: true,
     subjectShards: 100,
     overrides: {},
@@ -132,14 +132,14 @@ describe('EppoClient E2E test', () => {
 
   describe('setLogger', () => {
     beforeAll(() => {
-      storage.setEntries({ [experimentName]: mockExperimentConfig });
+      storage.setEntries({ [flagKey]: mockExperimentConfig });
     });
 
     it('Invokes logger for queued events', () => {
       const mockLogger = td.object<IAssignmentLogger>();
 
       const client = new EppoClient(storage);
-      client.getAssignment('subject-to-be-logged', experimentName);
+      client.getAssignment('subject-to-be-logged', flagKey);
       client.setLogger(mockLogger);
 
       expect(td.explain(mockLogger.logAssignment).callCount).toEqual(1);
@@ -153,7 +153,7 @@ describe('EppoClient E2E test', () => {
 
       const client = new EppoClient(storage);
 
-      client.getAssignment('subject-to-be-logged', experimentName);
+      client.getAssignment('subject-to-be-logged', flagKey);
       client.setLogger(mockLogger);
       expect(td.explain(mockLogger.logAssignment).callCount).toEqual(1);
 
@@ -166,7 +166,7 @@ describe('EppoClient E2E test', () => {
 
       const client = new EppoClient(storage);
       for (let i = 0; i < MAX_EVENT_QUEUE_SIZE + 100; i++) {
-        client.getAssignment(`subject-to-be-logged-${i}`, experimentName);
+        client.getAssignment(`subject-to-be-logged-${i}`, flagKey);
       }
       client.setLogger(mockLogger);
       expect(td.explain(mockLogger.logAssignment).callCount).toEqual(MAX_EVENT_QUEUE_SIZE);
@@ -218,7 +218,7 @@ describe('EppoClient E2E test', () => {
 
   it('returns subject from overrides when enabled is true', () => {
     window.localStorage.setItem(
-      experimentName,
+      flagKey,
       JSON.stringify({
         ...mockExperimentConfig,
         typedOverrides: {
@@ -227,7 +227,7 @@ describe('EppoClient E2E test', () => {
       }),
     );
     const client = new EppoClient(storage);
-    const assignment = client.getAssignment('subject-10', experimentName);
+    const assignment = client.getAssignment('subject-10', flagKey);
     expect(assignment).toEqual('control');
   });
 
@@ -240,22 +240,22 @@ describe('EppoClient E2E test', () => {
       },
     };
 
-    storage.setEntries({ [experimentName]: entry });
+    storage.setEntries({ [flagKey]: entry });
 
     const client = new EppoClient(storage);
-    const assignment = client.getAssignment('subject-10', experimentName);
+    const assignment = client.getAssignment('subject-10', flagKey);
     expect(assignment).toEqual('control');
   });
 
   it('logs variation assignment', () => {
     const mockLogger = td.object<IAssignmentLogger>();
 
-    storage.setEntries({ [experimentName]: mockExperimentConfig });
+    storage.setEntries({ [flagKey]: mockExperimentConfig });
     const client = new EppoClient(storage);
     client.setLogger(mockLogger);
 
     const subjectAttributes = { foo: 3 };
-    const assignment = client.getAssignment('subject-10', experimentName, subjectAttributes);
+    const assignment = client.getAssignment('subject-10', flagKey, subjectAttributes);
 
     expect(assignment).toEqual('control');
     expect(td.explain(mockLogger.logAssignment).callCount).toEqual(1);
@@ -266,12 +266,12 @@ describe('EppoClient E2E test', () => {
     const mockLogger = td.object<IAssignmentLogger>();
     td.when(mockLogger.logAssignment(td.matchers.anything())).thenThrow(new Error('logging error'));
 
-    storage.setEntries({ [experimentName]: mockExperimentConfig });
+    storage.setEntries({ [flagKey]: mockExperimentConfig });
     const client = new EppoClient(storage);
     client.setLogger(mockLogger);
 
     const subjectAttributes = { foo: 3 };
-    const assignment = client.getAssignment('subject-10', experimentName, subjectAttributes);
+    const assignment = client.getAssignment('subject-10', flagKey, subjectAttributes);
 
     expect(assignment).toEqual('control');
   });
@@ -293,14 +293,14 @@ describe('EppoClient E2E test', () => {
       ],
     };
 
-    storage.setEntries({ [experimentName]: entry });
+    storage.setEntries({ [flagKey]: entry });
 
     const client = new EppoClient(storage);
-    let assignment = client.getAssignment('subject-10', experimentName, { appVersion: 9 });
+    let assignment = client.getAssignment('subject-10', flagKey, { appVersion: 9 });
     expect(assignment).toEqual(null);
-    assignment = client.getAssignment('subject-10', experimentName);
+    assignment = client.getAssignment('subject-10', flagKey);
     expect(assignment).toEqual(null);
-    assignment = client.getAssignment('subject-10', experimentName, { appVersion: 11 });
+    assignment = client.getAssignment('subject-10', flagKey, { appVersion: 11 });
     expect(assignment).toEqual('control');
   });
 
@@ -376,23 +376,23 @@ describe('EppoClient E2E test', () => {
     let client: EppoClient;
 
     beforeAll(() => {
-      storage.setEntries({ [experimentName]: mockExperimentConfig });
+      storage.setEntries({ [flagKey]: mockExperimentConfig });
       client = new EppoClient(storage);
     });
 
     describe('onPreAssignment', () => {
       it('called with experiment key and subject id', () => {
         const mockHooks = td.object<IAssignmentHooks>();
-        client.getAssignment('subject-identifer', experimentName, {}, mockHooks);
+        client.getAssignment('subject-identifer', flagKey, {}, mockHooks);
         expect(td.explain(mockHooks.onPreAssignment).callCount).toEqual(1);
-        expect(td.explain(mockHooks.onPreAssignment).calls[0].args[0]).toEqual(experimentName);
+        expect(td.explain(mockHooks.onPreAssignment).calls[0].args[0]).toEqual(flagKey);
         expect(td.explain(mockHooks.onPreAssignment).calls[0].args[1]).toEqual('subject-identifer');
       });
 
       it('overrides returned assignment', async () => {
         const variation = await client.getAssignment(
           'subject-identifer',
-          experimentName,
+          flagKey,
           {},
           {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -417,7 +417,7 @@ describe('EppoClient E2E test', () => {
       it('uses regular assignment logic if onPreAssignment returns null', async () => {
         const variation = await client.getAssignment(
           'subject-identifer',
-          experimentName,
+          flagKey,
           {},
           {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -444,10 +444,10 @@ describe('EppoClient E2E test', () => {
       it('called with assigned variation after assignment', async () => {
         const mockHooks = td.object<IAssignmentHooks>();
         const subject = 'subject-identifier';
-        const variation = client.getAssignment(subject, experimentName, {}, mockHooks);
+        const variation = client.getAssignment(subject, flagKey, {}, mockHooks);
         expect(td.explain(mockHooks.onPostAssignment).callCount).toEqual(1);
         expect(td.explain(mockHooks.onPostAssignment).callCount).toEqual(1);
-        expect(td.explain(mockHooks.onPostAssignment).calls[0].args[0]).toEqual(experimentName);
+        expect(td.explain(mockHooks.onPostAssignment).calls[0].args[0]).toEqual(flagKey);
         expect(td.explain(mockHooks.onPostAssignment).calls[0].args[1]).toEqual(subject);
         expect(td.explain(mockHooks.onPostAssignment).calls[0].args[2]).toEqual(
           EppoValue.String(variation ?? ''),

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -91,19 +91,11 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes: Record<string, any> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): string | null {
-    const { allocationKey, assignment } = this.getAssignmentInternal(
-      subjectKey,
+    return this.getAssignmentVariation(subjectKey,
       flagKey,
       subjectAttributes,
       assignmentHooks,
-      ValueType.StringType,
-    );
-    assignmentHooks?.onPostAssignment(flagKey, subjectKey, assignment, allocationKey);
-
-    if (assignment !== null && allocationKey !== null)
-      this.logAssignment(flagKey, allocationKey, assignment, subjectKey, subjectAttributes);
-
-    return assignment?.stringValue ?? null;
+      ValueType.StringType)?.stringValue ?? null;
   }
 
   public getStringAssignment(
@@ -112,19 +104,11 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes: Record<string, EppoValue> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): string | null {
-    const { allocationKey, assignment } = this.getAssignmentInternal(
-      subjectKey,
+    return this.getAssignmentVariation(subjectKey,
       flagKey,
       subjectAttributes,
       assignmentHooks,
-      ValueType.StringType,
-    );
-    assignmentHooks?.onPostAssignment(flagKey, subjectKey, assignment, allocationKey);
-
-    if (assignment !== null && allocationKey !== null)
-      this.logAssignment(flagKey, allocationKey, assignment, subjectKey, subjectAttributes);
-
-    return assignment?.stringValue ?? null;
+      ValueType.StringType)?.stringValue ?? null;
   }
 
   getBoolAssignment(
@@ -133,19 +117,11 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes: Record<string, EppoValue> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): boolean | null {
-    const { allocationKey, assignment } = this.getAssignmentInternal(
-      subjectKey,
+    return this.getAssignmentVariation(subjectKey,
       flagKey,
       subjectAttributes,
       assignmentHooks,
-      ValueType.BoolType,
-    );
-    assignmentHooks?.onPostAssignment(flagKey, subjectKey, assignment, allocationKey);
-
-    if (assignment !== null && allocationKey !== null)
-      this.logAssignment(flagKey, allocationKey, assignment, subjectKey, subjectAttributes);
-
-    return assignment?.boolValue ?? null;
+      ValueType.BoolType)?.boolValue ?? null;
   }
 
   getNumericAssignment(
@@ -154,19 +130,11 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes?: Record<string, EppoValue>,
     assignmentHooks?: IAssignmentHooks | undefined,
   ): number | null {
-    const { allocationKey, assignment } = this.getAssignmentInternal(
-      subjectKey,
+    return this.getAssignmentVariation(subjectKey,
       flagKey,
       subjectAttributes,
       assignmentHooks,
-      ValueType.NumericType,
-    );
-    assignmentHooks?.onPostAssignment(flagKey, subjectKey, assignment, allocationKey);
-
-    if (assignment !== null && allocationKey !== null)
-      this.logAssignment(flagKey, allocationKey, assignment, subjectKey, subjectAttributes);
-
-    return assignment?.numericValue ?? null;
+      ValueType.NumericType)?.numericValue ?? null;
   }
 
   public getJSONAssignment(
@@ -175,19 +143,33 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes: Record<string, EppoValue> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): string | null {
+    return this.getAssignmentVariation(subjectKey,
+      flagKey,
+      subjectAttributes,
+      assignmentHooks,
+      ValueType.StringType)?.stringValue ?? null;
+  }
+
+  private getAssignmentVariation(
+    subjectKey: string,
+    flagKey: string,
+    subjectAttributes: Record<string, EppoValue> = {},
+    assignmentHooks: IAssignmentHooks | undefined,
+    valueType: ValueType,
+  ): EppoValue | null {
     const { allocationKey, assignment } = this.getAssignmentInternal(
       subjectKey,
       flagKey,
       subjectAttributes,
       assignmentHooks,
-      ValueType.StringType,
+      valueType,
     );
     assignmentHooks?.onPostAssignment(flagKey, subjectKey, assignment, allocationKey);
 
     if (assignment !== null && allocationKey !== null)
       this.logAssignment(flagKey, allocationKey, assignment, subjectKey, subjectAttributes);
 
-    return assignment?.stringValue ?? null;
+    return assignment
   }
 
   private getAssignmentInternal(

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -20,7 +20,7 @@ export interface IEppoClient {
    * Maps a subject to a variation for a given experiment.
    *
    * @param subjectKey an identifier of the experiment subject, for example a user ID.
-   * @param experimentKey experiment identifier
+   * @param flagKey feature flag identifier
    * @param subjectAttributes optional attributes associated with the subject, for example name and email.
    * The subject attributes are used for evaluating any targeting rules tied to the experiment.
    * @param assignmentHooks optional interface for pre and post assignment hooks
@@ -29,7 +29,7 @@ export interface IEppoClient {
    */
   getAssignment(
     subjectKey: string,
-    experimentKey: string,
+    flagKey: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     subjectAttributes?: Record<string, any>,
     assignmentHooks?: IAssignmentHooks,
@@ -39,7 +39,7 @@ export interface IEppoClient {
    * Maps a subject to a variation for a given experiment.
    *
    * @param subjectKey an identifier of the experiment subject, for example a user ID.
-   * @param experimentKey experiment identifier
+   * @param flagKey feature flag identifier
    * @param subjectAttributes optional attributes associated with the subject, for example name and email.
    * The subject attributes are used for evaluating any targeting rules tied to the experiment.
    * @returns a variation value if the subject is part of the experiment sample, otherwise null
@@ -47,7 +47,7 @@ export interface IEppoClient {
    */
   getStringAssignment(
     subjectKey: string,
-    experimentKey: string,
+    flagKey: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     subjectAttributes?: Record<string, any>,
     assignmentHooks?: IAssignmentHooks,
@@ -55,7 +55,7 @@ export interface IEppoClient {
 
   getBoolAssignment(
     subjectKey: string,
-    experimentKey: string,
+    flagKey: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     subjectAttributes?: Record<string, any>,
     assignmentHooks?: IAssignmentHooks,
@@ -63,7 +63,7 @@ export interface IEppoClient {
 
   getNumericAssignment(
     subjectKey: string,
-    experimentKey: string,
+    flagKey: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     subjectAttributes?: Record<string, any>,
     assignmentHooks?: IAssignmentHooks,
@@ -71,7 +71,7 @@ export interface IEppoClient {
 
   getJSONAssignment(
     subjectKey: string,
-    experimentKey: string,
+    flagKey: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     subjectAttributes?: Record<string, any>,
     assignmentHooks?: IAssignmentHooks,
@@ -82,124 +82,124 @@ export default class EppoClient implements IEppoClient {
   private queuedEvents: IAssignmentEvent[] = [];
   private assignmentLogger: IAssignmentLogger | undefined;
 
-  constructor(private configurationStore: IConfigurationStore) {}
+  constructor(private configurationStore: IConfigurationStore) { }
 
   public getAssignment(
     subjectKey: string,
-    experimentKey: string,
+    flagKey: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     subjectAttributes: Record<string, any> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): string | null {
     const assignment = this.getAssignmentInternal(
       subjectKey,
-      experimentKey,
+      flagKey,
       subjectAttributes,
       assignmentHooks,
       ValueType.StringType,
     );
-    assignmentHooks?.onPostAssignment(experimentKey, subjectKey, assignment);
+    assignmentHooks?.onPostAssignment(flagKey, subjectKey, assignment);
 
     if (assignment !== null)
-      this.logAssignment(experimentKey, assignment, subjectKey, subjectAttributes);
+      this.logAssignment(flagKey, assignment, subjectKey, subjectAttributes);
 
     return assignment?.stringValue ?? null;
   }
 
   public getStringAssignment(
     subjectKey: string,
-    experimentKey: string,
+    flagKey: string,
     subjectAttributes: Record<string, EppoValue> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): string | null {
     const assignment = this.getAssignmentInternal(
       subjectKey,
-      experimentKey,
+      flagKey,
       subjectAttributes,
       assignmentHooks,
       ValueType.StringType,
     );
-    assignmentHooks?.onPostAssignment(experimentKey, subjectKey, assignment);
+    assignmentHooks?.onPostAssignment(flagKey, subjectKey, assignment);
 
     if (assignment !== null)
-      this.logAssignment(experimentKey, assignment, subjectKey, subjectAttributes);
+      this.logAssignment(flagKey, assignment, subjectKey, subjectAttributes);
 
     return assignment?.stringValue ?? null;
   }
 
   getBoolAssignment(
     subjectKey: string,
-    experimentKey: string,
+    flagKey: string,
     subjectAttributes: Record<string, EppoValue> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): boolean | null {
     const assignment = this.getAssignmentInternal(
       subjectKey,
-      experimentKey,
+      flagKey,
       subjectAttributes,
       assignmentHooks,
       ValueType.BoolType,
     );
-    assignmentHooks?.onPostAssignment(experimentKey, subjectKey, assignment);
+    assignmentHooks?.onPostAssignment(flagKey, subjectKey, assignment);
 
     if (assignment !== null)
-      this.logAssignment(experimentKey, assignment, subjectKey, subjectAttributes);
+      this.logAssignment(flagKey, assignment, subjectKey, subjectAttributes);
 
     return assignment?.boolValue ?? null;
   }
 
   getNumericAssignment(
     subjectKey: string,
-    experimentKey: string,
+    flagKey: string,
     subjectAttributes?: Record<string, EppoValue>,
     assignmentHooks?: IAssignmentHooks | undefined,
   ): number | null {
     const assignment = this.getAssignmentInternal(
       subjectKey,
-      experimentKey,
+      flagKey,
       subjectAttributes,
       assignmentHooks,
       ValueType.NumericType,
     );
 
     if (assignment !== null)
-      this.logAssignment(experimentKey, assignment, subjectKey, subjectAttributes);
+      this.logAssignment(flagKey, assignment, subjectKey, subjectAttributes);
 
     return assignment?.numericValue ?? null;
   }
 
   public getJSONAssignment(
     subjectKey: string,
-    experimentKey: string,
+    flagKey: string,
     subjectAttributes: Record<string, EppoValue> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): string | null {
     const assignment = this.getAssignmentInternal(
       subjectKey,
-      experimentKey,
+      flagKey,
       subjectAttributes,
       assignmentHooks,
       ValueType.StringType,
     );
-    assignmentHooks?.onPostAssignment(experimentKey, subjectKey, assignment);
+    assignmentHooks?.onPostAssignment(flagKey, subjectKey, assignment);
 
     if (assignment !== null)
-      this.logAssignment(experimentKey, assignment, subjectKey, subjectAttributes);
+      this.logAssignment(flagKey, assignment, subjectKey, subjectAttributes);
 
     return assignment?.stringValue ?? null;
   }
 
   private getAssignmentInternal(
     subjectKey: string,
-    experimentKey: string,
+    flagKey: string,
     subjectAttributes = {},
     assignmentHooks: IAssignmentHooks | undefined,
     valueType: ValueType,
   ): EppoValue | null {
     validateNotBlank(subjectKey, 'Invalid argument: subjectKey cannot be blank');
-    validateNotBlank(experimentKey, 'Invalid argument: experimentKey cannot be blank');
+    validateNotBlank(flagKey, 'Invalid argument: flagKey cannot be blank');
 
-    const experimentConfig = this.configurationStore.get<IExperimentConfiguration>(experimentKey);
+    const experimentConfig = this.configurationStore.get<IExperimentConfiguration>(flagKey);
     const allowListOverride = this.getSubjectVariationOverride(
       subjectKey,
       experimentConfig,
@@ -212,7 +212,7 @@ export default class EppoClient implements IEppoClient {
     if (!experimentConfig?.enabled) return null;
 
     // check for overridden assignment via hook
-    const overriddenAssignment = assignmentHooks?.onPreAssignment(experimentKey, subjectKey);
+    const overriddenAssignment = assignmentHooks?.onPreAssignment(flagKey, subjectKey);
     if (overriddenAssignment !== null && overriddenAssignment !== undefined) {
       return overriddenAssignment;
     }
@@ -223,14 +223,14 @@ export default class EppoClient implements IEppoClient {
 
     // Check if subject is in allocation sample.
     const allocation = experimentConfig.allocations[matchedRule.allocationKey];
-    if (!this.isInExperimentSample(subjectKey, experimentKey, experimentConfig, allocation))
+    if (!this.isInExperimentSample(subjectKey, flagKey, experimentConfig, allocation))
       return null;
 
     // Compute variation for subject.
     const { subjectShards } = experimentConfig;
     const { variations } = allocation;
 
-    const shard = getShard(`assignment-${subjectKey}-${experimentKey}`, subjectShards);
+    const shard = getShard(`assignment-${subjectKey}-${flagKey}`, subjectShards);
     const assignedVariation = variations.find((variation) =>
       isShardInRange(shard, variation.shardRange),
     )?.typedValue;
@@ -265,13 +265,15 @@ export default class EppoClient implements IEppoClient {
   }
 
   private logAssignment(
-    experiment: string,
+    flagKey: string,
     variation: EppoValue,
     subjectKey: string,
     subjectAttributes: Record<string, EppoValue> | undefined = {},
   ) {
     const event: IAssignmentEvent = {
-      experiment,
+      allocation: flagKey,
+      experiment: flagKey,
+      featureFlag: flagKey,
       variation: variation.toString(), // return the string representation to the logging callback
       timestamp: new Date().toISOString(),
       subject: subjectKey,
@@ -320,13 +322,13 @@ export default class EppoClient implements IEppoClient {
    */
   private isInExperimentSample(
     subjectKey: string,
-    experimentKey: string,
+    flagKey: string,
     experimentConfig: IExperimentConfiguration,
     allocation: IAllocation,
   ): boolean {
     const { subjectShards } = experimentConfig;
     const { percentExposure } = allocation;
-    const shard = getShard(`exposure-${subjectKey}-${experimentKey}`, subjectShards);
+    const shard = getShard(`exposure-${subjectKey}-${flagKey}`, subjectShards);
     return shard <= percentExposure * subjectShards;
   }
 }

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -91,7 +91,8 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes: Record<string, any> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): string | null {
-    return this.getAssignmentVariation(subjectKey,
+    return this.getAssignmentVariation(
+      subjectKey,
       flagKey,
       subjectAttributes,
       assignmentHooks,
@@ -104,7 +105,8 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes: Record<string, EppoValue> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): string | null {
-    return this.getAssignmentVariation(subjectKey,
+    return this.getAssignmentVariation(
+      subjectKey,
       flagKey,
       subjectAttributes,
       assignmentHooks,
@@ -117,7 +119,8 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes: Record<string, EppoValue> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): boolean | null {
-    return this.getAssignmentVariation(subjectKey,
+    return this.getAssignmentVariation(
+      subjectKey,
       flagKey,
       subjectAttributes,
       assignmentHooks,
@@ -130,7 +133,8 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes?: Record<string, EppoValue>,
     assignmentHooks?: IAssignmentHooks | undefined,
   ): number | null {
-    return this.getAssignmentVariation(subjectKey,
+    return this.getAssignmentVariation(
+      subjectKey,
       flagKey,
       subjectAttributes,
       assignmentHooks,
@@ -143,7 +147,8 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes: Record<string, EppoValue> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): string | null {
-    return this.getAssignmentVariation(subjectKey,
+    return this.getAssignmentVariation(
+      subjectKey,
       flagKey,
       subjectAttributes,
       assignmentHooks,

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -184,7 +184,7 @@ export default class EppoClient implements IEppoClient {
     );
     assignmentHooks?.onPostAssignment(flagKey, subjectKey, assignment, allocationKey);
 
-    if (assignment !== null)
+    if (assignment !== null && allocationKey !== null)
       this.logAssignment(flagKey, allocationKey, assignment, subjectKey, subjectAttributes);
 
     return assignment?.stringValue ?? null;

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -82,7 +82,7 @@ export default class EppoClient implements IEppoClient {
   private queuedEvents: IAssignmentEvent[] = [];
   private assignmentLogger: IAssignmentLogger | undefined;
 
-  constructor(private configurationStore: IConfigurationStore) { }
+  constructor(private configurationStore: IConfigurationStore) {}
 
   public getAssignment(
     subjectKey: string,
@@ -91,12 +91,15 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes: Record<string, any> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): string | null {
-    return this.getAssignmentVariation(
-      subjectKey,
-      flagKey,
-      subjectAttributes,
-      assignmentHooks,
-      ValueType.StringType)?.stringValue ?? null;
+    return (
+      this.getAssignmentVariation(
+        subjectKey,
+        flagKey,
+        subjectAttributes,
+        assignmentHooks,
+        ValueType.StringType,
+      )?.stringValue ?? null
+    );
   }
 
   public getStringAssignment(
@@ -105,12 +108,15 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes: Record<string, EppoValue> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): string | null {
-    return this.getAssignmentVariation(
-      subjectKey,
-      flagKey,
-      subjectAttributes,
-      assignmentHooks,
-      ValueType.StringType)?.stringValue ?? null;
+    return (
+      this.getAssignmentVariation(
+        subjectKey,
+        flagKey,
+        subjectAttributes,
+        assignmentHooks,
+        ValueType.StringType,
+      )?.stringValue ?? null
+    );
   }
 
   getBoolAssignment(
@@ -119,12 +125,15 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes: Record<string, EppoValue> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): boolean | null {
-    return this.getAssignmentVariation(
-      subjectKey,
-      flagKey,
-      subjectAttributes,
-      assignmentHooks,
-      ValueType.BoolType)?.boolValue ?? null;
+    return (
+      this.getAssignmentVariation(
+        subjectKey,
+        flagKey,
+        subjectAttributes,
+        assignmentHooks,
+        ValueType.BoolType,
+      )?.boolValue ?? null
+    );
   }
 
   getNumericAssignment(
@@ -133,12 +142,15 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes?: Record<string, EppoValue>,
     assignmentHooks?: IAssignmentHooks | undefined,
   ): number | null {
-    return this.getAssignmentVariation(
-      subjectKey,
-      flagKey,
-      subjectAttributes,
-      assignmentHooks,
-      ValueType.NumericType)?.numericValue ?? null;
+    return (
+      this.getAssignmentVariation(
+        subjectKey,
+        flagKey,
+        subjectAttributes,
+        assignmentHooks,
+        ValueType.NumericType,
+      )?.numericValue ?? null
+    );
   }
 
   public getJSONAssignment(
@@ -147,12 +159,15 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes: Record<string, EppoValue> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): string | null {
-    return this.getAssignmentVariation(
-      subjectKey,
-      flagKey,
-      subjectAttributes,
-      assignmentHooks,
-      ValueType.StringType)?.stringValue ?? null;
+    return (
+      this.getAssignmentVariation(
+        subjectKey,
+        flagKey,
+        subjectAttributes,
+        assignmentHooks,
+        ValueType.StringType,
+      )?.stringValue ?? null
+    );
   }
 
   private getAssignmentVariation(
@@ -174,7 +189,7 @@ export default class EppoClient implements IEppoClient {
     if (!assignment.isNullType() && allocationKey !== null)
       this.logAssignment(flagKey, allocationKey, assignment, subjectKey, subjectAttributes);
 
-    return assignment
+    return assignment;
   }
 
   private getAssignmentInternal(
@@ -183,7 +198,7 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes = {},
     assignmentHooks: IAssignmentHooks | undefined,
     valueType: ValueType,
-  ): { allocationKey: string | null; assignment: EppoValue; } {
+  ): { allocationKey: string | null; assignment: EppoValue } {
     validateNotBlank(subjectKey, 'Invalid argument: subjectKey cannot be blank');
     validateNotBlank(flagKey, 'Invalid argument: flagKey cannot be blank');
 
@@ -198,8 +213,8 @@ export default class EppoClient implements IEppoClient {
 
     if (allowListOverride) {
       if (!allowListOverride.isExpectedType()) return nullAssignment;
-      return { ...nullAssignment, assignment: allowListOverride }
-    };
+      return { ...nullAssignment, assignment: allowListOverride };
+    }
 
     // Check for disabled flag.
     if (!experimentConfig?.enabled) return nullAssignment;
@@ -229,17 +244,20 @@ export default class EppoClient implements IEppoClient {
       isShardInRange(shard, variation.shardRange),
     )?.typedValue;
 
-    const internalAssignment = { allocationKey: matchedRule.allocationKey, assignment: EppoValue.Null() };
+    const internalAssignment = {
+      allocationKey: matchedRule.allocationKey,
+      assignment: EppoValue.Null(),
+    };
 
     switch (valueType) {
       case ValueType.BoolType:
-        internalAssignment['assignment'] = EppoValue.Bool(assignedVariation as boolean)
+        internalAssignment['assignment'] = EppoValue.Bool(assignedVariation as boolean);
         break;
       case ValueType.NumericType:
-        internalAssignment['assignment'] = EppoValue.Numeric(assignedVariation as number)
+        internalAssignment['assignment'] = EppoValue.Numeric(assignedVariation as number);
         break;
       case ValueType.StringType:
-        internalAssignment['assignment'] = EppoValue.String(assignedVariation as string)
+        internalAssignment['assignment'] = EppoValue.String(assignedVariation as string);
         break;
       default:
         return nullAssignment;

--- a/src/eppo_value.ts
+++ b/src/eppo_value.ts
@@ -38,6 +38,23 @@ export class EppoValue {
     }
   }
 
+  isExpectedType(): boolean {
+    switch (this.valueType) {
+      case ValueType.BoolType:
+        return typeof this.boolValue === 'boolean';
+      case ValueType.NumericType:
+        return typeof this.numericValue === 'number';
+      case ValueType.StringType:
+        return typeof this.stringValue === 'string';
+      default:
+        return true;
+    }
+  }
+
+  isNullType(): boolean {
+    return this.valueType === ValueType.NullType;
+  }
+
   static Bool(value: boolean): EppoValue {
     return new EppoValue(ValueType.BoolType, value, undefined, undefined);
   }


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: [FF-924](https://linear.app/eppo/issue/FF-924/update-js-sdk-common-with-allocation-key)

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

## Description
[//]: # (Describe your changes in detail)

Renames `experimentKey` to `flagKey`
Extracts `allocationKey` from output of `getAssignmentInternal`
Updates `onPostAssignment` to optionally include `allocationKey`
Update `logAssignment` to use `allocationKey` in creation of the event object that goes to the logger (here's where we get the `allocation`, `experiment`, and `featureFlag` event attributes)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
