### PR TITLE
Fix missing getParsedJSONAssignment property in IEppoClient

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -109,7 +109,8 @@ export default class EppoClient implements IEppoClient {
   public getStringAssignment(
     subjectKey: string,
     flagKey: string,
-    subjectAttributes: Record<string, EppoValue> = {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    subjectAttributes: Record<string, any> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): string | null {
     return (
@@ -126,7 +127,8 @@ export default class EppoClient implements IEppoClient {
   getBoolAssignment(
     subjectKey: string,
     flagKey: string,
-    subjectAttributes: Record<string, EppoValue> = {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    subjectAttributes: Record<string, any> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): boolean | null {
     return (
@@ -160,7 +162,8 @@ export default class EppoClient implements IEppoClient {
   public getJSONStringAssignment(
     subjectKey: string,
     flagKey: string,
-    subjectAttributes: Record<string, EppoValue> = {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    subjectAttributes: Record<string, any> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): string | null {
     return (
@@ -177,7 +180,8 @@ export default class EppoClient implements IEppoClient {
   public getParsedJSONAssignment(
     subjectKey: string,
     flagKey: string,
-    subjectAttributes: Record<string, EppoValue> = {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    subjectAttributes: Record<string, any> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): object | null {
     return (
@@ -194,7 +198,8 @@ export default class EppoClient implements IEppoClient {
   private getAssignmentVariation(
     subjectKey: string,
     flagKey: string,
-    subjectAttributes: Record<string, EppoValue> = {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    subjectAttributes: Record<string, any> = {},
     assignmentHooks: IAssignmentHooks | undefined,
     valueType?: ValueType,
   ): EppoValue {
@@ -300,7 +305,8 @@ export default class EppoClient implements IEppoClient {
     allocationKey: string,
     variation: EppoValue,
     subjectKey: string,
-    subjectAttributes: Record<string, EppoValue> | undefined = {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    subjectAttributes: Record<string, any> | undefined = {},
   ) {
     const event: IAssignmentEvent = {
       allocation: allocationKey,

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -76,6 +76,14 @@ export interface IEppoClient {
     subjectAttributes?: Record<string, any>,
     assignmentHooks?: IAssignmentHooks,
   ): string | null;
+
+  getParsedJSONAssignment(
+    subjectKey: string,
+    flagKey: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    subjectAttributes?: Record<string, any>,
+    assignmentHooks?: IAssignmentHooks,
+  ): object | null;
 }
 
 export default class EppoClient implements IEppoClient {


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

## Description
[//]: # (Describe your changes in detail)

Hit this error while updating the react native sdk. I guess the other js/node sdks weren't relying on `IEppoClient`, but this should be consistent.

```
src/__tests__/index.test.tsx:302:29 - error TS2339: Property 'getParsedJSONAssignment' does not exist on type 'IEppoClient'.

302           const oa = client.getParsedJSONAssignment(subjectKey, experiment);
                                ~~~~~~~~~~~~~~~~~~~~~~~
```

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
