### PR TITLE
adds graceful failure mode; all public functions have a try/catch (FF…

### DIFF
--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -143,6 +143,10 @@ describe('EppoClient E2E test', () => {
       });
     });
 
+    afterAll(() => {
+      td.reset();
+    });
+
     it('returns null when graceful failure if error encountered', async () => {
       client.setIsGracefulFailureMode(true);
 

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -130,6 +130,63 @@ describe('EppoClient E2E test', () => {
     },
   };
 
+  describe('error encountered', () => {
+    let client: EppoClient;
+    const mockHooks = td.object<IAssignmentHooks>();
+
+    beforeAll(() => {
+      storage.setEntries({ [flagKey]: mockExperimentConfig });
+      client = new EppoClient(storage);
+
+      td.replace(EppoClient.prototype, 'getAssignmentVariation', function () {
+        throw new Error('So Graceful Error');
+      });
+    });
+
+    it('returns null when graceful failure if error encountered', async () => {
+      client.setIsGracefulFailureMode(true);
+
+      expect(client.getAssignment('subject-identifer', flagKey, {}, mockHooks)).toBeNull();
+      expect(client.getBoolAssignment('subject-identifer', flagKey, {}, mockHooks)).toBeNull();
+      expect(
+        client.getJSONStringAssignment('subject-identifer', flagKey, {}, mockHooks),
+      ).toBeNull();
+      expect(client.getNumericAssignment('subject-identifer', flagKey, {}, mockHooks)).toBeNull();
+      expect(
+        client.getParsedJSONAssignment('subject-identifer', flagKey, {}, mockHooks),
+      ).toBeNull();
+      expect(client.getStringAssignment('subject-identifer', flagKey, {}, mockHooks)).toBeNull();
+    });
+
+    it('throws error when graceful failure is false', async () => {
+      client.setIsGracefulFailureMode(false);
+
+      expect(() => {
+        client.getAssignment('subject-identifer', flagKey, {}, mockHooks);
+      }).toThrow();
+
+      expect(() => {
+        client.getBoolAssignment('subject-identifer', flagKey, {}, mockHooks);
+      }).toThrow();
+
+      expect(() => {
+        client.getJSONStringAssignment('subject-identifer', flagKey, {}, mockHooks);
+      }).toThrow();
+
+      expect(() => {
+        client.getParsedJSONAssignment('subject-identifer', flagKey, {}, mockHooks);
+      }).toThrow();
+
+      expect(() => {
+        client.getNumericAssignment('subject-identifer', flagKey, {}, mockHooks);
+      }).toThrow();
+
+      expect(() => {
+        client.getStringAssignment('subject-identifer', flagKey, {}, mockHooks);
+      }).toThrow();
+    });
+  });
+
   describe('setLogger', () => {
     beforeAll(() => {
       storage.setEntries({ [flagKey]: mockExperimentConfig });

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -89,6 +89,7 @@ export interface IEppoClient {
 export default class EppoClient implements IEppoClient {
   private queuedEvents: IAssignmentEvent[] = [];
   private assignmentLogger: IAssignmentLogger | undefined;
+  private isGracefulFailureMode = true;
 
   constructor(private configurationStore: IConfigurationStore) {}
 
@@ -100,10 +101,18 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes: Record<string, any> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): string | null {
-    return (
-      this.getAssignmentVariation(subjectKey, flagKey, subjectAttributes, assignmentHooks)
-        .stringValue ?? null
-    );
+    try {
+      return (
+        this.getAssignmentVariation(subjectKey, flagKey, subjectAttributes, assignmentHooks)
+          .stringValue ?? null
+      );
+    } catch (error) {
+      if (this.isGracefulFailureMode) {
+        console.error(`[Eppo SDK] Error getting assignment: ${error.message}`);
+        return null;
+      }
+      throw error;
+    }
   }
 
   public getStringAssignment(
@@ -113,15 +122,23 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes: Record<string, any> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): string | null {
-    return (
-      this.getAssignmentVariation(
-        subjectKey,
-        flagKey,
-        subjectAttributes,
-        assignmentHooks,
-        ValueType.StringType,
-      ).stringValue ?? null
-    );
+    try {
+      return (
+        this.getAssignmentVariation(
+          subjectKey,
+          flagKey,
+          subjectAttributes,
+          assignmentHooks,
+          ValueType.StringType,
+        ).stringValue ?? null
+      );
+    } catch (error) {
+      if (this.isGracefulFailureMode) {
+        console.error(`[Eppo SDK] Error getting string assignment: ${error.message}`);
+        return null;
+      }
+      throw error;
+    }
   }
 
   getBoolAssignment(
@@ -131,15 +148,23 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes: Record<string, any> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): boolean | null {
-    return (
-      this.getAssignmentVariation(
-        subjectKey,
-        flagKey,
-        subjectAttributes,
-        assignmentHooks,
-        ValueType.BoolType,
-      ).boolValue ?? null
-    );
+    try {
+      return (
+        this.getAssignmentVariation(
+          subjectKey,
+          flagKey,
+          subjectAttributes,
+          assignmentHooks,
+          ValueType.BoolType,
+        ).boolValue ?? null
+      );
+    } catch (error) {
+      if (this.isGracefulFailureMode) {
+        console.error(`[Eppo SDK] Error getting bool assignment: ${error.message}`);
+        return null;
+      }
+      throw error;
+    }
   }
 
   getNumericAssignment(
@@ -148,15 +173,23 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes?: Record<string, EppoValue>,
     assignmentHooks?: IAssignmentHooks | undefined,
   ): number | null {
-    return (
-      this.getAssignmentVariation(
-        subjectKey,
-        flagKey,
-        subjectAttributes,
-        assignmentHooks,
-        ValueType.NumericType,
-      ).numericValue ?? null
-    );
+    try {
+      return (
+        this.getAssignmentVariation(
+          subjectKey,
+          flagKey,
+          subjectAttributes,
+          assignmentHooks,
+          ValueType.NumericType,
+        ).numericValue ?? null
+      );
+    } catch (error) {
+      if (this.isGracefulFailureMode) {
+        console.error(`[Eppo SDK] Error getting numeric assignment: ${error.message}`);
+        return null;
+      }
+      throw error;
+    }
   }
 
   public getJSONStringAssignment(
@@ -166,15 +199,23 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes: Record<string, any> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): string | null {
-    return (
-      this.getAssignmentVariation(
-        subjectKey,
-        flagKey,
-        subjectAttributes,
-        assignmentHooks,
-        ValueType.JSONType,
-      ).stringValue ?? null
-    );
+    try {
+      return (
+        this.getAssignmentVariation(
+          subjectKey,
+          flagKey,
+          subjectAttributes,
+          assignmentHooks,
+          ValueType.JSONType,
+        ).stringValue ?? null
+      );
+    } catch (error) {
+      if (this.isGracefulFailureMode) {
+        console.error(`[Eppo SDK] Error getting JSON string assignment: ${error.message}`);
+        return null;
+      }
+      throw error;
+    }
   }
 
   public getParsedJSONAssignment(
@@ -184,15 +225,23 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes: Record<string, any> = {},
     assignmentHooks?: IAssignmentHooks | undefined,
   ): object | null {
-    return (
-      this.getAssignmentVariation(
-        subjectKey,
-        flagKey,
-        subjectAttributes,
-        assignmentHooks,
-        ValueType.JSONType,
-      ).objectValue ?? null
-    );
+    try {
+      return (
+        this.getAssignmentVariation(
+          subjectKey,
+          flagKey,
+          subjectAttributes,
+          assignmentHooks,
+          ValueType.JSONType,
+        ).objectValue ?? null
+      );
+    } catch (error) {
+      if (this.isGracefulFailureMode) {
+        console.error(`[Eppo SDK] Error getting parsed JSON assignment: ${error.message}`);
+        return null;
+      }
+      throw error;
+    }
   }
 
   private getAssignmentVariation(
@@ -286,6 +335,10 @@ export default class EppoClient implements IEppoClient {
   public setLogger(logger: IAssignmentLogger) {
     this.assignmentLogger = logger;
     this.flushQueuedEvents(); // log any events that may have been queued while initializing
+  }
+
+  public setIsGracefulFailureMode(gracefulFailureMode: boolean) {
+    this.isGracefulFailureMode = gracefulFailureMode;
   }
 
   private flushQueuedEvents() {

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -107,11 +107,7 @@ export default class EppoClient implements IEppoClient {
           .stringValue ?? null
       );
     } catch (error) {
-      if (this.isGracefulFailureMode) {
-        console.error(`[Eppo SDK] Error getting assignment: ${error.message}`);
-        return null;
-      }
-      throw error;
+      return this.rethrowIfNotGraceful(error);
     }
   }
 
@@ -133,11 +129,7 @@ export default class EppoClient implements IEppoClient {
         ).stringValue ?? null
       );
     } catch (error) {
-      if (this.isGracefulFailureMode) {
-        console.error(`[Eppo SDK] Error getting string assignment: ${error.message}`);
-        return null;
-      }
-      throw error;
+      return this.rethrowIfNotGraceful(error);
     }
   }
 
@@ -159,11 +151,7 @@ export default class EppoClient implements IEppoClient {
         ).boolValue ?? null
       );
     } catch (error) {
-      if (this.isGracefulFailureMode) {
-        console.error(`[Eppo SDK] Error getting bool assignment: ${error.message}`);
-        return null;
-      }
-      throw error;
+      return this.rethrowIfNotGraceful(error);
     }
   }
 
@@ -184,11 +172,7 @@ export default class EppoClient implements IEppoClient {
         ).numericValue ?? null
       );
     } catch (error) {
-      if (this.isGracefulFailureMode) {
-        console.error(`[Eppo SDK] Error getting numeric assignment: ${error.message}`);
-        return null;
-      }
-      throw error;
+      return this.rethrowIfNotGraceful(error);
     }
   }
 
@@ -210,11 +194,7 @@ export default class EppoClient implements IEppoClient {
         ).stringValue ?? null
       );
     } catch (error) {
-      if (this.isGracefulFailureMode) {
-        console.error(`[Eppo SDK] Error getting JSON string assignment: ${error.message}`);
-        return null;
-      }
-      throw error;
+      return this.rethrowIfNotGraceful(error);
     }
   }
 
@@ -236,12 +216,16 @@ export default class EppoClient implements IEppoClient {
         ).objectValue ?? null
       );
     } catch (error) {
-      if (this.isGracefulFailureMode) {
-        console.error(`[Eppo SDK] Error getting parsed JSON assignment: ${error.message}`);
-        return null;
-      }
-      throw error;
+      return this.rethrowIfNotGraceful(error);
     }
+  }
+
+  private rethrowIfNotGraceful(err: Error): null {
+    if (this.isGracefulFailureMode) {
+      console.error(`[Eppo SDK] Error getting assignment: ${err.message}`);
+      return null;
+    }
+    throw err;
   }
 
   private getAssignmentVariation(


### PR DESCRIPTION
…-968)

---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Exceptions within the Eppo SDK should not bubble up to the customers' applications.

## Description
[//]: # (Describe your changes in detail)

By default the graceful mode is enabled; all exceptions are captured in the top level public methods and logged.

For development the graceful mode can be disabled:

```
client.setIsGracefulFailureMode(false)
```

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

It was easy to test the logger because we can pass a mock - it wasn't obvious to me how to trigger an exception to be able to test the graceful mode. We'd need to stub `getAssignmentVariation` but this seems unnecessary.

Suggestions welcome.

## deployment plan

Bump version number and import into upstream.

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
