### PR TITLE
assignment logging cache prevents duplicate invocations (FF-1069)

### DIFF
--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '18.x'
+          node-version: '16.x'
       - uses: actions/cache@v2
         with:
           path: './node_modules'
@@ -35,7 +35,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '18.x'
+          node-version: '16.x'
       - uses: actions/cache@v2
         with:
           path: './node_modules'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: '16.x'
       - run: yarn install
       - run: yarn test
       - uses: JS-DevTools/npm-publish@v1

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "axios": "^0.27.2",
+    "lru-cache": "^10.0.1",
     "md5": "^2.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "/dist"
   ],
   "types": "./dist/index.d.ts",
+  "engines": {
+    "node": ">=16.20"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/assignment-cache.ts
+++ b/src/assignment-cache.ts
@@ -15,6 +15,8 @@ interface Cacheable {
   has(key: string): boolean;
 }
 
+export type AvailableCacheTypes = Map<string, string> | LRUCache<string, string>;
+
 export abstract class AssignmentCache<T extends Cacheable> {
   // key -> variation value hash
   protected cache: T;

--- a/src/assignment-cache.ts
+++ b/src/assignment-cache.ts
@@ -9,13 +9,11 @@ export interface AssignmentCacheKey {
   variationValue: EppoValue;
 }
 
-interface Cacheable {
+export interface Cacheable {
   get(key: string): string | undefined;
   set(key: string, value: string): void;
   has(key: string): boolean;
 }
-
-export type AvailableCacheTypes = Map<string, string> | LRUCache<string, string>;
 
 export abstract class AssignmentCache<T extends Cacheable> {
   // key -> variation value hash

--- a/src/assignment-cache.ts
+++ b/src/assignment-cache.ts
@@ -2,16 +2,16 @@ import { LRUCache } from 'lru-cache';
 
 export interface AssignmentCacheKey {
   subjectKey: string;
+  flagKey: string;
   allocationKey: string;
-  variationKey: string;
 }
 
 export abstract class AssignmentCache {
   abstract hasAssigned(key: AssignmentCacheKey): boolean;
   abstract logAssignment(key: AssignmentCacheKey): void;
 
-  protected getCacheKey({ subjectKey, allocationKey, variationKey }: AssignmentCacheKey): string {
-    return `${subjectKey}-${allocationKey}-${variationKey}`;
+  protected getCacheKey({ subjectKey, flagKey, allocationKey }: AssignmentCacheKey): string {
+    return `subject:${subjectKey}-flag:${flagKey}-allocation:${allocationKey}`;
   }
 }
 

--- a/src/assignment-cache.ts
+++ b/src/assignment-cache.ts
@@ -41,7 +41,7 @@ export abstract class AssignmentCache<T extends Cacheable> {
     return true;
   }
 
-  logAssignment(key: AssignmentCacheKey): void {
+  setLastLoggedAssignment(key: AssignmentCacheKey): void {
     this.cache.set(this.getCacheKey(key), key.variationValue.toHashedString());
   }
 

--- a/src/assignment-cache.ts
+++ b/src/assignment-cache.ts
@@ -1,17 +1,30 @@
 import { LRUCache } from 'lru-cache';
 
+import { EppoValue } from './eppo_value';
+
 export interface AssignmentCacheKey {
   subjectKey: string;
   flagKey: string;
   allocationKey: string;
+  variationValue: EppoValue;
 }
 
 export abstract class AssignmentCache {
   abstract hasLoggedAssignment(key: AssignmentCacheKey): boolean;
   abstract logAssignment(key: AssignmentCacheKey): void;
 
-  protected getCacheKey({ subjectKey, flagKey, allocationKey }: AssignmentCacheKey): string {
-    return `subject:${subjectKey}-flag:${flagKey}-allocation:${allocationKey}`;
+  protected getCacheKey({
+    subjectKey,
+    flagKey,
+    allocationKey,
+    variationValue,
+  }: AssignmentCacheKey): string {
+    return [
+      `subject:${subjectKey}`,
+      `flag:${flagKey}`,
+      `allocation:${allocationKey}`,
+      `variation:${variationValue.toHashedString()}`,
+    ].join('-');
   }
 }
 

--- a/src/assignment-cache.ts
+++ b/src/assignment-cache.ts
@@ -7,7 +7,7 @@ export interface AssignmentCacheKey {
 }
 
 export abstract class AssignmentCache {
-  abstract hasAssigned(key: AssignmentCacheKey): boolean;
+  abstract hasLoggedAssignment(key: AssignmentCacheKey): boolean;
   abstract logAssignment(key: AssignmentCacheKey): void;
 
   protected getCacheKey({ subjectKey, flagKey, allocationKey }: AssignmentCacheKey): string {
@@ -29,7 +29,7 @@ export class NonExpiringAssignmentCache extends AssignmentCache {
     this.cache = new Set();
   }
 
-  hasAssigned(key: AssignmentCacheKey): boolean {
+  hasLoggedAssignment(key: AssignmentCacheKey): boolean {
     return this.cache.has(this.getCacheKey(key));
   }
 
@@ -55,7 +55,7 @@ export class LRUAssignmentCache extends AssignmentCache {
     this.cache = new LRUCache<string, boolean>({ max: maxSize });
   }
 
-  hasAssigned(key: AssignmentCacheKey): boolean {
+  hasLoggedAssignment(key: AssignmentCacheKey): boolean {
     return this.cache.has(this.getCacheKey(key));
   }
 

--- a/src/assignment-cache.ts
+++ b/src/assignment-cache.ts
@@ -1,0 +1,65 @@
+import { LRUCache } from 'lru-cache';
+
+export interface AssignmentCacheKey {
+  subjectKey: string;
+  allocationKey: string;
+  variationKey: string;
+}
+
+export abstract class AssignmentCache {
+  abstract hasAssigned(key: AssignmentCacheKey): boolean;
+  abstract logAssignment(key: AssignmentCacheKey): void;
+
+  protected getCacheKey({ subjectKey, allocationKey, variationKey }: AssignmentCacheKey): string {
+    return `${subjectKey}-${allocationKey}-${variationKey}`;
+  }
+}
+
+/**
+ * A cache that never expires.
+ *
+ * The primary use case is for client-side SDKs, where the cache is only used
+ * for a single user.
+ */
+export class NonExpiringAssignmentCache extends AssignmentCache {
+  private cache: Set<string>;
+
+  constructor() {
+    super();
+    this.cache = new Set();
+  }
+
+  hasAssigned(key: AssignmentCacheKey): boolean {
+    return this.cache.has(this.getCacheKey(key));
+  }
+
+  logAssignment(key: AssignmentCacheKey): void {
+    this.cache.add(this.getCacheKey(key));
+  }
+}
+
+/**
+ * A cache that uses the LRU algorithm to evict the least recently used items.
+ *
+ * It is used to limit the size of the cache.
+ *
+ * The primary use case is for server-side SDKs, where the cache is shared across
+ * multiple users. In this case, the cache size should be set to the maximum number
+ * of users that can be active at the same time.
+ */
+export class LRUAssignmentCache extends AssignmentCache {
+  private cache: LRUCache<string, boolean>;
+
+  constructor(maxSize: number) {
+    super();
+    this.cache = new LRUCache<string, boolean>({ max: maxSize });
+  }
+
+  hasAssigned(key: AssignmentCacheKey): boolean {
+    return this.cache.has(this.getCacheKey(key));
+  }
+
+  logAssignment(key: AssignmentCacheKey): void {
+    this.cache.set(this.getCacheKey(key), true);
+  }
+}

--- a/src/assignment-cache.ts
+++ b/src/assignment-cache.ts
@@ -41,8 +41,7 @@ export class NonExpiringAssignmentCache extends AssignmentCache {
 
     // the subject has been assigned to a different variation
     // than was previously logged.
-    // in this case we need to log the assignment again;
-    // clear the cache and return false
+    // in this case we need to log the assignment again.
     if (this.cache.get(this.getCacheKey(key)) !== key.variationValue.toHashedString()) {
       return false;
     }
@@ -80,8 +79,7 @@ export class LRUAssignmentCache extends AssignmentCache {
 
     // the subject has been assigned to a different variation
     // than was previously logged.
-    // in this case we need to log the assignment again;
-    // clear the cache and return false
+    // in this case we need to log the assignment again.
     if (this.cache.get(this.getCacheKey(key)) !== key.variationValue.toHashedString()) {
       return false;
     }

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -13,7 +13,6 @@ import {
   readAssignmentTestData,
   readMockRacResponse,
 } from '../../test/testHelpers';
-import { LRUAssignmentCache, NonExpiringAssignmentCache } from '../assignment-cache';
 import { IAssignmentHooks } from '../assignment-hooks';
 import { IAssignmentLogger } from '../assignment-logger';
 import { IConfigurationStore } from '../configuration-store';
@@ -377,7 +376,7 @@ describe('EppoClient E2E test', () => {
       storage.setEntries({ [flagKey]: mockExperimentConfig });
       const client = new EppoClient(storage);
       client.setLogger(mockLogger);
-      client.setAssignmentCache(undefined);
+      client.disableAssignmentCache();
 
       client.getAssignment('subject-10', flagKey);
       client.getAssignment('subject-10', flagKey);
@@ -392,7 +391,7 @@ describe('EppoClient E2E test', () => {
       storage.setEntries({ [flagKey]: mockExperimentConfig });
       const client = new EppoClient(storage);
       client.setLogger(mockLogger);
-      client.setAssignmentCache(new NonExpiringAssignmentCache());
+      client.useNonExpiringAssignmentCache();
 
       client.getAssignment('subject-10', flagKey);
       client.getAssignment('subject-10', flagKey);
@@ -407,7 +406,7 @@ describe('EppoClient E2E test', () => {
       storage.setEntries({ [flagKey]: mockExperimentConfig });
       const client = new EppoClient(storage);
       client.setLogger(mockLogger);
-      client.setAssignmentCache(new LRUAssignmentCache(2));
+      client.useLRUAssignmentCache(2);
 
       client.getAssignment('subject-10', flagKey); // logged
       client.getAssignment('subject-10', flagKey); // cached
@@ -456,7 +455,7 @@ describe('EppoClient E2E test', () => {
       });
       const client = new EppoClient(storage);
       client.setLogger(mockLogger);
-      client.setAssignmentCache(new NonExpiringAssignmentCache());
+      client.useNonExpiringAssignmentCache();
 
       client.getAssignment('subject-10', flagKey);
       client.getAssignment('subject-10', flagKey);
@@ -477,7 +476,7 @@ describe('EppoClient E2E test', () => {
       storage.setEntries({ [flagKey]: mockExperimentConfig });
       const client = new EppoClient(storage);
       client.setLogger(mockLogger);
-      client.setAssignmentCache(new NonExpiringAssignmentCache());
+      client.useNonExpiringAssignmentCache();
 
       storage.setEntries({
         [flagKey]: {
@@ -549,7 +548,7 @@ describe('EppoClient E2E test', () => {
       const mockLogger = td.object<IAssignmentLogger>();
       const client = new EppoClient(storage);
       client.setLogger(mockLogger);
-      client.setAssignmentCache(new NonExpiringAssignmentCache());
+      client.useNonExpiringAssignmentCache();
 
       // original configuration version
       storage.setEntries({ [flagKey]: mockExperimentConfig });

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -370,12 +370,18 @@ describe('EppoClient E2E test', () => {
   });
 
   describe('assignment logging deduplication', () => {
-    it('logs duplicate assignments without an assignment cache', () => {
-      const mockLogger = td.object<IAssignmentLogger>();
+    let client: EppoClient;
+    let mockLogger: IAssignmentLogger;
+
+    beforeEach(() => {
+      mockLogger = td.object<IAssignmentLogger>();
 
       storage.setEntries({ [flagKey]: mockExperimentConfig });
-      const client = new EppoClient(storage);
+      client = new EppoClient(storage);
       client.setLogger(mockLogger);
+    });
+
+    it('logs duplicate assignments without an assignment cache', () => {
       client.disableAssignmentCache();
 
       client.getAssignment('subject-10', flagKey);
@@ -386,11 +392,6 @@ describe('EppoClient E2E test', () => {
     });
 
     it('does not log duplicate assignments', () => {
-      const mockLogger = td.object<IAssignmentLogger>();
-
-      storage.setEntries({ [flagKey]: mockExperimentConfig });
-      const client = new EppoClient(storage);
-      client.setLogger(mockLogger);
       client.useNonExpiringAssignmentCache();
 
       client.getAssignment('subject-10', flagKey);
@@ -401,11 +402,6 @@ describe('EppoClient E2E test', () => {
     });
 
     it('logs assignment again after the lru cache is full', () => {
-      const mockLogger = td.object<IAssignmentLogger>();
-
-      storage.setEntries({ [flagKey]: mockExperimentConfig });
-      const client = new EppoClient(storage);
-      client.setLogger(mockLogger);
       client.useLRUAssignmentCache(2);
 
       client.getAssignment('subject-10', flagKey); // logged
@@ -422,7 +418,6 @@ describe('EppoClient E2E test', () => {
     });
 
     it('does not cache assignments if the logger had an exception', () => {
-      const mockLogger = td.object<IAssignmentLogger>();
       td.when(mockLogger.logAssignment(td.matchers.anything())).thenThrow(
         new Error('logging error'),
       );
@@ -439,8 +434,6 @@ describe('EppoClient E2E test', () => {
     });
 
     it('logs for each unique flag', () => {
-      const mockLogger = td.object<IAssignmentLogger>();
-
       storage.setEntries({
         [flagKey]: mockExperimentConfig,
         'flag-2': {
@@ -452,8 +445,7 @@ describe('EppoClient E2E test', () => {
           name: 'flag-3',
         },
       });
-      const client = new EppoClient(storage);
-      client.setLogger(mockLogger);
+
       client.useNonExpiringAssignmentCache();
 
       client.getAssignment('subject-10', flagKey);
@@ -470,11 +462,6 @@ describe('EppoClient E2E test', () => {
     });
 
     it('logs twice for the same flag when rollout increases/flag changes', () => {
-      const mockLogger = td.object<IAssignmentLogger>();
-
-      storage.setEntries({ [flagKey]: mockExperimentConfig });
-      const client = new EppoClient(storage);
-      client.setLogger(mockLogger);
       client.useNonExpiringAssignmentCache();
 
       storage.setEntries({
@@ -544,9 +531,6 @@ describe('EppoClient E2E test', () => {
     });
 
     it('logs the same subject/flag/variation after two changes', () => {
-      const mockLogger = td.object<IAssignmentLogger>();
-      const client = new EppoClient(storage);
-      client.setLogger(mockLogger);
       client.useNonExpiringAssignmentCache();
 
       // original configuration version

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -418,7 +418,6 @@ describe('EppoClient E2E test', () => {
       client.getAssignment('subject-10', flagKey); // previously evicted, logged
       client.getAssignment('subject-12', flagKey); // cached
 
-      // call count should be 1 because the second call is a cache hit and not logged.
       expect(td.explain(mockLogger.logAssignment).callCount).toEqual(4);
     });
 

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -370,7 +370,7 @@ describe('EppoClient E2E test', () => {
   });
 
   describe('assignment logging deduplication', () => {
-    it('logs duplicate assignments with an assignment cache', () => {
+    it('logs duplicate assignments without an assignment cache', () => {
       const mockLogger = td.object<IAssignmentLogger>();
 
       storage.setEntries({ [flagKey]: mockExperimentConfig });
@@ -400,7 +400,7 @@ describe('EppoClient E2E test', () => {
       expect(td.explain(mockLogger.logAssignment).callCount).toEqual(1);
     });
 
-    it('logs assignment again after the cache is full', () => {
+    it('logs assignment again after the lru cache is full', () => {
       const mockLogger = td.object<IAssignmentLogger>();
 
       storage.setEntries({ [flagKey]: mockExperimentConfig });

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -378,7 +378,7 @@ export default class EppoClient implements IEppoClient {
     subjectAttributes: Record<string, any> | undefined = {},
   ) {
     if (
-      this.assignmentCache?.hasAssigned({
+      this.assignmentCache?.hasLoggedAssignment({
         flagKey,
         subjectKey,
         allocationKey,

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -1,4 +1,3 @@
-import { LRUCache } from 'lru-cache';
 import * as md5 from 'md5';
 
 import { AssignmentCache, AvailableCacheTypes } from '../assignment-cache';

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -1,6 +1,7 @@
+import { LRUCache } from 'lru-cache';
 import * as md5 from 'md5';
 
-import { AssignmentCache } from '../assignment-cache';
+import { AssignmentCache, AvailableCacheTypes } from '../assignment-cache';
 import { IAssignmentHooks } from '../assignment-hooks';
 import { IAssignmentEvent, IAssignmentLogger } from '../assignment-logger';
 import { IConfigurationStore } from '../configuration-store';
@@ -92,7 +93,7 @@ export default class EppoClient implements IEppoClient {
   private queuedEvents: IAssignmentEvent[] = [];
   private assignmentLogger: IAssignmentLogger | undefined;
   private isGracefulFailureMode = true;
-  private assignmentCache: AssignmentCache | undefined;
+  private assignmentCache: AssignmentCache<AvailableCacheTypes> | undefined;
 
   constructor(private configurationStore: IConfigurationStore) {}
 
@@ -349,7 +350,7 @@ export default class EppoClient implements IEppoClient {
     this.flushQueuedEvents(); // log any events that may have been queued while initializing
   }
 
-  public setAssignmentCache(assignmentCache: AssignmentCache | undefined) {
+  public setAssignmentCache(assignmentCache: AssignmentCache<AvailableCacheTypes> | undefined) {
     this.assignmentCache = assignmentCache;
   }
 

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -379,9 +379,9 @@ export default class EppoClient implements IEppoClient {
   ) {
     if (
       this.assignmentCache?.hasAssigned({
+        flagKey,
         subjectKey,
         allocationKey,
-        variationKey: variation.toString(),
       })
     ) {
       console.debug(
@@ -407,9 +407,9 @@ export default class EppoClient implements IEppoClient {
     try {
       this.assignmentLogger.logAssignment(event);
       this.assignmentCache?.logAssignment({
+        flagKey,
         subjectKey,
         allocationKey,
-        variationKey: variation.toString(),
       });
     } catch (error) {
       console.error(`[Eppo SDK] Error logging assignment event: ${error.message}`);

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -2,7 +2,7 @@ import * as md5 from 'md5';
 
 import {
   AssignmentCache,
-  AvailableCacheTypes,
+  Cacheable,
   LRUAssignmentCache,
   NonExpiringAssignmentCache,
 } from '../assignment-cache';
@@ -97,7 +97,7 @@ export default class EppoClient implements IEppoClient {
   private queuedEvents: IAssignmentEvent[] = [];
   private assignmentLogger: IAssignmentLogger | undefined;
   private isGracefulFailureMode = true;
-  private assignmentCache: AssignmentCache<AvailableCacheTypes> | undefined;
+  private assignmentCache: AssignmentCache<Cacheable> | undefined;
 
   constructor(private configurationStore: IConfigurationStore) {}
 

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -404,7 +404,7 @@ export default class EppoClient implements IEppoClient {
     }
     try {
       this.assignmentLogger.logAssignment(event);
-      this.assignmentCache?.logAssignment({
+      this.assignmentCache?.setLastLoggedAssignment({
         flagKey,
         subjectKey,
         allocationKey,

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -386,9 +386,6 @@ export default class EppoClient implements IEppoClient {
         variationValue: variation,
       })
     ) {
-      console.debug(
-        `[Eppo SDK] Assignment already logged for ${subjectKey}-${allocationKey}-${variation.toString()}; not executing Logger.`,
-      );
       return;
     }
 

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -1,6 +1,11 @@
 import * as md5 from 'md5';
 
-import { AssignmentCache, AvailableCacheTypes } from '../assignment-cache';
+import {
+  AssignmentCache,
+  AvailableCacheTypes,
+  LRUAssignmentCache,
+  NonExpiringAssignmentCache,
+} from '../assignment-cache';
 import { IAssignmentHooks } from '../assignment-hooks';
 import { IAssignmentEvent, IAssignmentLogger } from '../assignment-logger';
 import { IConfigurationStore } from '../configuration-store';
@@ -349,8 +354,19 @@ export default class EppoClient implements IEppoClient {
     this.flushQueuedEvents(); // log any events that may have been queued while initializing
   }
 
-  public setAssignmentCache(assignmentCache: AssignmentCache<AvailableCacheTypes> | undefined) {
-    this.assignmentCache = assignmentCache;
+  /**
+   * Assignment cache methods.
+   */
+  public disableAssignmentCache() {
+    this.assignmentCache = undefined;
+  }
+
+  public useNonExpiringAssignmentCache() {
+    this.assignmentCache = new NonExpiringAssignmentCache();
+  }
+
+  public useLRUAssignmentCache(maxSize: number) {
+    this.assignmentCache = new LRUAssignmentCache(maxSize);
   }
 
   public setIsGracefulFailureMode(gracefulFailureMode: boolean) {

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -382,6 +382,7 @@ export default class EppoClient implements IEppoClient {
         flagKey,
         subjectKey,
         allocationKey,
+        variationValue: variation,
       })
     ) {
       console.debug(
@@ -410,6 +411,7 @@ export default class EppoClient implements IEppoClient {
         flagKey,
         subjectKey,
         allocationKey,
+        variationValue: variation,
       });
     } catch (error) {
       console.error(`[Eppo SDK] Error logging assignment event: ${error.message}`);

--- a/src/eppo_value.spec.ts
+++ b/src/eppo_value.spec.ts
@@ -3,7 +3,7 @@ import { EppoValue } from './eppo_value';
 describe('EppoValue toHashedString function', () => {
   it('is NullType', () => {
     const myInstance = EppoValue.Null();
-    expect(myInstance.toHashedString()).toBe('d41d8cd98f00b204e9800998ecf8427e');
+    expect(myInstance.toHashedString()).toBe('37a6259cc0c1dae299a7866489dff0bd');
   });
 
   it('is JsonType', () => {

--- a/src/eppo_value.spec.ts
+++ b/src/eppo_value.spec.ts
@@ -1,5 +1,17 @@
 import { EppoValue } from './eppo_value';
 
+describe('EppoValue toHashedString function', () => {
+  it('is NullType', () => {
+    const myInstance = EppoValue.Null();
+    expect(myInstance.toHashedString()).toBe('d41d8cd98f00b204e9800998ecf8427e');
+  });
+
+  it('is JsonType', () => {
+    const myInstance = EppoValue.JSON('{"hello":"world"}', { hello: 'world' });
+    expect(myInstance.toHashedString()).toBe('fbc24bcc7a1794758fc1327fcfebdaf6');
+  });
+});
+
 describe('EppoValue toString function', () => {
   it('should return "null" when valueType is NullType', () => {
     const myInstance = EppoValue.Null();

--- a/src/eppo_value.ts
+++ b/src/eppo_value.ts
@@ -1,3 +1,5 @@
+import { getMD5Hash } from './obfuscation';
+
 export enum ValueType {
   NullType,
   BoolType,
@@ -68,6 +70,17 @@ export class EppoValue {
           return this.stringValue ?? '';
         }
     }
+  }
+
+  /**
+   * Useful when storing or transmitting the entire value,
+   * in particular the JsonType, is not desired.
+   *
+   * @returns MD5 hashed string of the value
+   */
+  toHashedString(): string {
+    const value = this.toString();
+    return getMD5Hash(value);
   }
 
   isExpectedType(): boolean {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3094,6 +3094,11 @@ lodash@^4.17.15, lodash@^4.17.21:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+lru-cache@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.1.tgz#0a3be479df549cca0e5d693ac402ff19537a6b7a"
+  integrity sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz"


### PR DESCRIPTION
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Eppo's assignment logger callback is invoked without consideration for duplicate events. These events add cost to our customers to transmit and store the extra data in their warehouses. Additionally, Eppo's computation is slower when processing these additional events.

We will augment the JS SDKs with a cache to mitigate duplicate assignments.

## Description
[//]: # (Describe your changes in detail)

Allows upstream clients to specify an `assignment logger cache` - given a key it will only allow a single invocation of the callback for it.

By default the client-side SDKs will use the `NonExpiringCache` and the nodejs server SDK will instantiate with the `LRUCache`.

Example usage:

```
  clientInstance = new EppoClient(configurationRequestor, poller);
  clientInstance.setLogger(config.assignmentLogger);

  clientInstance.setAssignmentCache(
    config.assignmentCache ?? new LRUAssignmentCache(ASSIGNMENT_CACHE_DEFAULT_MAX_ENTRIES),
  );
``` 

**Question for reviewers**

1. Should we implement the `LRUCache` here in the commons library or upstream in the nodejs server sdk?

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

New unit tests

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
