### PR TITLE
Sameeran/ff 1130 sdk assigns subjects to a holdout js common

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test-data:
 	cp ${gitDataDir}rac-experiments-v3.json ${testDataDir}
 	cp ${gitDataDir}rac-experiments-v3-obfuscated.json ${testDataDir}
 	cp -r ${gitDataDir}assignment-v2 ${testDataDir}
-	cp -r ${gitDataDir}assignment-v2-holdout/ ${testDataDir}assignment-v2
+	cp -r ${gitDataDir}assignment-v2-holdouts/. ${testDataDir}assignment-v2
 	rm -rf ${tempDir}
 
 ## prepare

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ test-data:
 	cp ${gitDataDir}rac-experiments-v3.json ${testDataDir}
 	cp ${gitDataDir}rac-experiments-v3-obfuscated.json ${testDataDir}
 	cp -r ${gitDataDir}assignment-v2 ${testDataDir}
+	cp -r ${gitDataDir}assignment-v2-holdout/. ${testDataDir}assignment-v2
 	rm -rf ${tempDir}
 
 ## prepare

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test-data:
 	cp ${gitDataDir}rac-experiments-v3.json ${testDataDir}
 	cp ${gitDataDir}rac-experiments-v3-obfuscated.json ${testDataDir}
 	cp -r ${gitDataDir}assignment-v2 ${testDataDir}
-	cp -r ${gitDataDir}assignment-v2-holdout/. ${testDataDir}assignment-v2
+	cp -r ${gitDataDir}assignment-v2-holdout/ ${testDataDir}assignment-v2
 	rm -rf ${tempDir}
 
 ## prepare

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "axios": "^0.27.2",
+    "axios": "^1.6.0",
     "lru-cache": "^10.0.1",
     "md5": "^2.3.0"
   }

--- a/src/assignment-logger.ts
+++ b/src/assignment-logger.ts
@@ -1,4 +1,9 @@
-export type HoldoutVariationType = 'status_quo' | 'all_shipped_variants' | null;
+export enum HoldoutVariationEnum {
+  STATUS_QUO = 'status_quo',
+  ALL_SHIPPED = 'all_shipped_variants',
+}
+
+export type NullableHoldoutVariationType = HoldoutVariationEnum | null;
 
 /**
  * Holds data about the variation a subject was assigned to.
@@ -43,7 +48,7 @@ export interface IAssignmentEvent {
   /**
    * The Eppo holdout variation for the assigned variation
    */
-  holdoutVariation: HoldoutVariationType;
+  holdoutVariation: NullableHoldoutVariationType;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   subjectAttributes: Record<string, any>;

--- a/src/assignment-logger.ts
+++ b/src/assignment-logger.ts
@@ -1,3 +1,5 @@
+export type HoldoutVariationType = 'status_quo' | 'all_shipped_variants' | null;
+
 /**
  * Holds data about the variation a subject was assigned to.
  * @public
@@ -32,6 +34,16 @@ export interface IAssignmentEvent {
    * The time the subject was exposed to the variation.
    */
   timestamp: string;
+
+  /**
+   * An Eppo holdout key
+   */
+  holdout: string | null;
+
+  /**
+   * The Eppo holdout variation for the assigned variation
+   */
+  holdoutVariation: HoldoutVariationType;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   subjectAttributes: Record<string, any>;

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -109,7 +109,7 @@ describe('EppoClient E2E test', () => {
             typedValue: 'control',
             shardRange: {
               start: 0,
-              end: 3400,
+              end: 3333,
             },
           },
           {
@@ -117,8 +117,8 @@ describe('EppoClient E2E test', () => {
             value: 'variant-1',
             typedValue: 'variant-1',
             shardRange: {
-              start: 3400,
-              end: 6700,
+              start: 3333,
+              end: 6667,
             },
           },
           {
@@ -126,7 +126,7 @@ describe('EppoClient E2E test', () => {
             value: 'variant-2',
             typedValue: 'variant-2',
             shardRange: {
-              start: 6700,
+              start: 6667,
               end: 10000,
             },
           },

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -613,27 +613,24 @@ describe('EppoClient E2E test', () => {
       allocations: {
         allocation1: {
           percentExposure: 1,
-          holdout: {
-            statusQuo: 'variation-7',
-            shipped: null,
-            percentExposure: 0.2,
-            keys: [
-              {
-                holdoutKey: 'holdout-2',
-                statusQuoShardRange: {
-                  start: 0,
-                  end: 50,
-                },
+          statusQuoVariationKey: 'variation-7',
+          shippedVariationKey: null,
+          holdouts: [
+            {
+              holdoutKey: 'holdout-2',
+              statusQuoShardRange: {
+                start: 0,
+                end: 50,
               },
-              {
-                holdoutKey: 'holdout-3',
-                statusQuoShardRange: {
-                  start: 51,
-                  end: 100,
-                },
+            },
+            {
+              holdoutKey: 'holdout-3',
+              statusQuoShardRange: {
+                start: 51,
+                end: 100,
               },
-            ],
-          },
+            },
+          ],
           variations: [
             {
               name: 'control',
@@ -706,35 +703,32 @@ describe('EppoClient E2E test', () => {
       allocations: {
         allocation1: {
           percentExposure: 1,
-          holdout: {
-            statusQuo: 'variation-7',
-            shipped: 'variation-8',
-            percentExposure: 0.2,
-            keys: [
-              {
-                holdoutKey: 'holdout-2',
-                statusQuoShardRange: {
-                  start: 0,
-                  end: 25,
-                },
-                shippedShardRange: {
-                  start: 26,
-                  end: 50,
-                },
+          statusQuoVariationKey: 'variation-7',
+          shippedVariationKey: 'variation-8',
+          holdouts: [
+            {
+              holdoutKey: 'holdout-2',
+              statusQuoShardRange: {
+                start: 0,
+                end: 25,
               },
-              {
-                holdoutKey: 'holdout-3',
-                statusQuoShardRange: {
-                  start: 51,
-                  end: 75,
-                },
-                shippedShardRange: {
-                  start: 76,
-                  end: 100,
-                },
+              shippedShardRange: {
+                start: 26,
+                end: 50,
               },
-            ],
-          },
+            },
+            {
+              holdoutKey: 'holdout-3',
+              statusQuoShardRange: {
+                start: 51,
+                end: 75,
+              },
+              shippedShardRange: {
+                start: 76,
+                end: 100,
+              },
+            },
+          ],
           variations: [
             {
               name: 'control',
@@ -1003,6 +997,11 @@ describe(' EppoClient getAssignment From Obfuscated RAC', () => {
         experiment,
         valueType,
       );
+
+      // if (experiment == 'experiment_with_holdout') {
+      //   const res = assignments.map((a) => (a == null ? a : a.stringValue));
+      //   console.log(res);
+      // }
 
       switch (valueType) {
         case ValueTestType.BoolType: {

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -603,6 +603,78 @@ describe('EppoClient E2E test', () => {
     expect(assignment).toEqual('control');
   });
 
+  it('returns variation in holdout and logs holdout key if subject is held out', () => {
+    const entry = {
+      ...mockExperimentConfig,
+      allocations: {
+        allocation1: {
+          percentExposure: 1,
+          holdout: [
+            {
+              statusQuoVariationKey: 'variation-7',
+              shippedVariationKey: null,
+              totalHoldoutExposure: 0.2,
+              keyRanges: [
+                {
+                  key: 'holdout-2',
+                  statusQuoShardRange: {
+                    start: 0,
+                    end: 50,
+                  },
+                },
+                {
+                  key: 'holdout-3',
+                  statusQuoShardRange: {
+                    start: 51,
+                    end: 100,
+                  },
+                },
+              ],
+            },
+          ],
+          variations: [
+            {
+              name: 'control',
+              value: 'control',
+              typedValue: 'control',
+              shardRange: {
+                start: 0,
+                end: 34,
+              },
+              variationKey: 'variation-7',
+            },
+            {
+              name: 'variant-1',
+              value: 'variant-1',
+              typedValue: 'variant-1',
+              shardRange: {
+                start: 34,
+                end: 67,
+              },
+              variationKey: 'variation-8',
+            },
+            {
+              name: 'variant-2',
+              value: 'variant-2',
+              typedValue: 'variant-2',
+              shardRange: {
+                start: 67,
+                end: 100,
+              },
+              variationKey: 'variation-9',
+            },
+          ],
+        },
+      },
+    };
+
+    storage.setEntries({ [flagKey]: entry });
+
+    const client = new EppoClient(storage);
+    const assignment = client.getAssignment('subject-10', flagKey);
+    expect(assignment).toEqual('control');
+  });
+
   function getAssignmentsWithSubjectAttributes(
     subjectsWithAttributes: {
       subjectKey: string;

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -99,7 +99,9 @@ describe('EppoClient E2E test', () => {
     allocations: {
       allocation1: {
         percentExposure: 1,
-        holdout: null,
+        statusQuoVariationKey: null,
+        shippedVariationKey: null,
+        holdouts: [],
         variations: [
           {
             name: 'control',
@@ -471,7 +473,9 @@ describe('EppoClient E2E test', () => {
           allocations: {
             allocation1: {
               percentExposure: 1,
-              holdout: null,
+              statusQuoVariationKey: null,
+              shippedVariationKey: null,
+              holdouts: [],
               variations: [
                 {
                   name: 'control',
@@ -504,7 +508,9 @@ describe('EppoClient E2E test', () => {
           allocations: {
             allocation1: {
               percentExposure: 1,
-              holdout: null,
+              statusQuoVariationKey: null,
+              shippedVariationKey: null,
+              holdouts: [],
               variations: [
                 {
                   name: 'control',
@@ -549,7 +555,9 @@ describe('EppoClient E2E test', () => {
           allocations: {
             allocation1: {
               percentExposure: 1,
-              holdout: null,
+              statusQuoVariationKey: null,
+              shippedVariationKey: null,
+              holdouts: [],
               variations: [
                 {
                   name: 'some-new-treatment',
@@ -620,14 +628,14 @@ describe('EppoClient E2E test', () => {
               holdoutKey: 'holdout-2',
               statusQuoShardRange: {
                 start: 0,
-                end: 50,
+                end: 4,
               },
             },
             {
               holdoutKey: 'holdout-3',
               statusQuoShardRange: {
-                start: 51,
-                end: 100,
+                start: 4,
+                end: 8,
               },
             },
           ],
@@ -674,24 +682,24 @@ describe('EppoClient E2E test', () => {
     client.setLogger(mockLogger);
     td.reset();
 
-    // subject-10 --> holdout exposure shard is 10, holdout assignment shard is 38
-    let assignment = client.getAssignment('subject-10', flagKey);
+    // subject-8 --> holdout shard is 1
+    let assignment = client.getAssignment('subject-8', flagKey);
     expect(assignment).toEqual('control');
     expect(td.explain(mockLogger.logAssignment).calls[0].args[0].holdoutVariation).toEqual(
       'status_quo',
     );
     expect(td.explain(mockLogger.logAssignment).calls[0].args[0].holdout).toEqual('holdout-2');
 
-    // subject-15 --> holdout exposure shard is 3, holdout assignment shard is 62
-    assignment = client.getAssignment('subject-15', flagKey);
+    // subject-88 --> holdout shard is 6
+    assignment = client.getAssignment('subject-88', flagKey);
     expect(assignment).toEqual('control');
     expect(td.explain(mockLogger.logAssignment).calls[1].args[0].holdoutVariation).toEqual(
       'status_quo',
     );
     expect(td.explain(mockLogger.logAssignment).calls[1].args[0].holdout).toEqual('holdout-3');
 
-    // subject-80 --> holdout exposure shard is 27 (outside holdout), non-holdout assignment shard is 85
-    assignment = client.getAssignment('subject-80', flagKey);
+    // subject-1 --> holdout shard is 27 (outside holdout), non-holdout assignment shard is 96
+    assignment = client.getAssignment('subject-1', flagKey);
     expect(assignment).toEqual('variant-2');
     expect(td.explain(mockLogger.logAssignment).calls[2].args[0].holdoutVariation).toBeNull();
     expect(td.explain(mockLogger.logAssignment).calls[2].args[0].holdout).toBeNull();
@@ -710,22 +718,22 @@ describe('EppoClient E2E test', () => {
               holdoutKey: 'holdout-2',
               statusQuoShardRange: {
                 start: 0,
-                end: 25,
+                end: 2,
               },
               shippedShardRange: {
-                start: 26,
-                end: 50,
+                start: 2,
+                end: 4,
               },
             },
             {
               holdoutKey: 'holdout-3',
               statusQuoShardRange: {
-                start: 51,
-                end: 75,
+                start: 4,
+                end: 6,
               },
               shippedShardRange: {
-                start: 76,
-                end: 100,
+                start: 6,
+                end: 8,
               },
             },
           ],
@@ -772,40 +780,40 @@ describe('EppoClient E2E test', () => {
     client.setLogger(mockLogger);
     td.reset();
 
-    // subject-3 --> holdout exposure shard is 2, holdout assignment shard is 20
-    let assignment = client.getAssignment('subject-3', flagKey);
+    // subject-8 --> holdout shard is 1
+    let assignment = client.getAssignment('subject-8', flagKey);
     expect(assignment).toEqual('control');
     expect(td.explain(mockLogger.logAssignment).calls[0].args[0].holdoutVariation).toEqual(
       'status_quo',
     );
     expect(td.explain(mockLogger.logAssignment).calls[0].args[0].holdout).toEqual('holdout-2');
 
-    // subject-10 --> holdout exposure shard is 10, holdout assignment shard is 38
-    assignment = client.getAssignment('subject-10', flagKey);
+    // subject-398 --> holdout shard is 3
+    assignment = client.getAssignment('subject-398', flagKey);
     expect(assignment).toEqual('variant-1');
     expect(td.explain(mockLogger.logAssignment).calls[1].args[0].holdoutVariation).toEqual(
       'all_shipped_variants',
     );
     expect(td.explain(mockLogger.logAssignment).calls[1].args[0].holdout).toEqual('holdout-2');
 
-    // subject-15 --> holdout exposure shard is 3, holdout assignment shard is 62
-    assignment = client.getAssignment('subject-15', flagKey);
+    // subject-131 --> holdout shard is 5
+    assignment = client.getAssignment('subject-131', flagKey);
     expect(assignment).toEqual('control');
     expect(td.explain(mockLogger.logAssignment).calls[2].args[0].holdoutVariation).toEqual(
       'status_quo',
     );
     expect(td.explain(mockLogger.logAssignment).calls[2].args[0].holdout).toEqual('holdout-3');
 
-    // subject-97 --> holdout exposure shard is 5, holdout assignment shard is 98
-    assignment = client.getAssignment('subject-97', flagKey);
+    // subject-88 --> holdout shard is 6
+    assignment = client.getAssignment('subject-88', flagKey);
     expect(assignment).toEqual('variant-1');
     expect(td.explain(mockLogger.logAssignment).calls[3].args[0].holdoutVariation).toEqual(
       'all_shipped_variants',
     );
     expect(td.explain(mockLogger.logAssignment).calls[3].args[0].holdout).toEqual('holdout-3');
 
-    // subject-80 --> holdout exposure shard is 27 (outside holdout), non-holdout assignment shard is 85
-    assignment = client.getAssignment('subject-80', flagKey);
+    // subject-1 --> holdout shard is 75 (outside holdout), non-holdout assignment shard is 96
+    assignment = client.getAssignment('subject-1', flagKey);
     expect(assignment).toEqual('variant-2');
     expect(td.explain(mockLogger.logAssignment).calls[4].args[0].holdoutVariation).toBeNull();
     expect(td.explain(mockLogger.logAssignment).calls[4].args[0].holdout).toBeNull();
@@ -997,11 +1005,6 @@ describe(' EppoClient getAssignment From Obfuscated RAC', () => {
         experiment,
         valueType,
       );
-
-      // if (experiment == 'experiment_with_holdout') {
-      //   const res = assignments.map((a) => (a == null ? a : a.stringValue));
-      //   console.log(res);
-      // }
 
       switch (valueType) {
         case ValueTestType.BoolType: {

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -600,9 +600,9 @@ describe('EppoClient E2E test', () => {
 
     const client = new EppoClient(storage);
     let assignment = client.getAssignment('subject-10', flagKey, { appVersion: 9 });
-    expect(assignment).toEqual(null);
+    expect(assignment).toBeNull();
     assignment = client.getAssignment('subject-10', flagKey);
-    expect(assignment).toEqual(null);
+    expect(assignment).toBeNull();
     assignment = client.getAssignment('subject-10', flagKey, { appVersion: 11 });
     expect(assignment).toEqual('control');
   });
@@ -696,8 +696,8 @@ describe('EppoClient E2E test', () => {
     // subject-80 --> holdout exposure shard is 27 (outside holdout), non-holdout assignment shard is 85
     assignment = client.getAssignment('subject-80', flagKey);
     expect(assignment).toEqual('variant-2');
-    expect(td.explain(mockLogger.logAssignment).calls[2].args[0].holdoutVariation).toEqual(null);
-    expect(td.explain(mockLogger.logAssignment).calls[2].args[0].holdout).toEqual(null);
+    expect(td.explain(mockLogger.logAssignment).calls[2].args[0].holdoutVariation).toBeNull();
+    expect(td.explain(mockLogger.logAssignment).calls[2].args[0].holdout).toBeNull();
   });
 
   it('returns the shipped variation and logs all_shipped_variants if subject is in holdout', () => {
@@ -813,8 +813,8 @@ describe('EppoClient E2E test', () => {
     // subject-80 --> holdout exposure shard is 27 (outside holdout), non-holdout assignment shard is 85
     assignment = client.getAssignment('subject-80', flagKey);
     expect(assignment).toEqual('variant-2');
-    expect(td.explain(mockLogger.logAssignment).calls[4].args[0].holdoutVariation).toEqual(null);
-    expect(td.explain(mockLogger.logAssignment).calls[4].args[0].holdout).toEqual(null);
+    expect(td.explain(mockLogger.logAssignment).calls[4].args[0].holdoutVariation).toBeNull();
+    expect(td.explain(mockLogger.logAssignment).calls[4].args[0].holdout).toBeNull();
   });
 
   function getAssignmentsWithSubjectAttributes(
@@ -946,7 +946,7 @@ describe('EppoClient E2E test', () => {
           },
         );
 
-        expect(variation).not.toEqual(null);
+        expect(variation).not.toBeNull();
         expect(td.explain(mockLogger.logAssignment).callCount).toEqual(1);
       });
     });

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -99,6 +99,7 @@ describe('EppoClient E2E test', () => {
     allocations: {
       allocation1: {
         percentExposure: 1,
+        holdout: null,
         variations: [
           {
             name: 'control',
@@ -470,6 +471,7 @@ describe('EppoClient E2E test', () => {
           allocations: {
             allocation1: {
               percentExposure: 1,
+              holdout: null,
               variations: [
                 {
                   name: 'control',
@@ -502,6 +504,7 @@ describe('EppoClient E2E test', () => {
           allocations: {
             allocation1: {
               percentExposure: 1,
+              holdout: null,
               variations: [
                 {
                   name: 'control',
@@ -546,6 +549,7 @@ describe('EppoClient E2E test', () => {
           allocations: {
             allocation1: {
               percentExposure: 1,
+              holdout: null,
               variations: [
                 {
                   name: 'some-new-treatment',

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -687,13 +687,14 @@ describe('EppoClient E2E test', () => {
     // subject-79 --> holdout shard is 186
     let assignment = client.getAssignment('subject-79', flagKey);
     expect(assignment).toEqual('control');
+    // Only log holdout key (not variation) if this is an experiment allocation
     expect(td.explain(mockLogger.logAssignment).calls[0].args[0].holdoutVariation).toBeNull();
     expect(td.explain(mockLogger.logAssignment).calls[0].args[0].holdout).toEqual('holdout-2');
 
     // subject-8 --> holdout shard is 201
     assignment = client.getAssignment('subject-8', flagKey);
     expect(assignment).toEqual('control');
-    // Do not log holdout variation if this is an experiment allocation
+    // Only log holdout key (not variation) if this is an experiment allocation
     expect(td.explain(mockLogger.logAssignment).calls[1].args[0].holdoutVariation).toBeNull();
     expect(td.explain(mockLogger.logAssignment).calls[1].args[0].holdout).toEqual('holdout-3');
 
@@ -743,7 +744,7 @@ describe('EppoClient E2E test', () => {
               typedValue: 'control',
               shardRange: {
                 start: 0,
-                end: 3333,
+                end: 0,
               },
               variationKey: 'variation-7',
             },
@@ -752,8 +753,8 @@ describe('EppoClient E2E test', () => {
               value: 'variant-1',
               typedValue: 'variant-1',
               shardRange: {
-                start: 3333,
-                end: 6667,
+                start: 0,
+                end: 0,
               },
               variationKey: 'variation-8',
             },
@@ -762,7 +763,7 @@ describe('EppoClient E2E test', () => {
               value: 'variant-2',
               typedValue: 'variant-2',
               shardRange: {
-                start: 6667,
+                start: 0,
                 end: 10000,
               },
               variationKey: 'variation-9',
@@ -782,6 +783,7 @@ describe('EppoClient E2E test', () => {
     // subject-227 --> holdout shard is 57
     let assignment = client.getAssignment('subject-227', flagKey);
     expect(assignment).toEqual('control');
+    // Log both holdout key and variation if this is a rollout allocation
     expect(td.explain(mockLogger.logAssignment).calls[0].args[0].holdoutVariation).toEqual(
       'status_quo',
     );
@@ -790,6 +792,7 @@ describe('EppoClient E2E test', () => {
     // subject-79 --> holdout shard is 186
     assignment = client.getAssignment('subject-79', flagKey);
     expect(assignment).toEqual('variant-1');
+    // Log both holdout key and variation if this is a rollout allocation
     expect(td.explain(mockLogger.logAssignment).calls[1].args[0].holdoutVariation).toEqual(
       'all_shipped_variants',
     );
@@ -798,6 +801,7 @@ describe('EppoClient E2E test', () => {
     // subject-8 --> holdout shard is 201
     assignment = client.getAssignment('subject-8', flagKey);
     expect(assignment).toEqual('control');
+    // Log both holdout key and variation if this is a rollout allocation
     expect(td.explain(mockLogger.logAssignment).calls[2].args[0].holdoutVariation).toEqual(
       'status_quo',
     );
@@ -806,6 +810,7 @@ describe('EppoClient E2E test', () => {
     // subject-50 --> holdout shard is 347
     assignment = client.getAssignment('subject-50', flagKey);
     expect(assignment).toEqual('variant-1');
+    // Log both holdout key and variation if this is a rollout allocation
     expect(td.explain(mockLogger.logAssignment).calls[3].args[0].holdoutVariation).toEqual(
       'all_shipped_variants',
     );

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -380,10 +380,8 @@ export default class EppoClient implements IEppoClient {
       }
       return assignedVariation;
     });
-    let holdoutKey = null;
-    if (matchingHoldout) {
-      holdoutKey = matchingHoldout.holdoutKey;
-    } else {
+    const holdoutKey = matchingHoldout?.holdoutKey ?? null;
+    if (!matchingHoldout) {
       const assignmentShard = getShard(`assignment-${subjectKey}-${flagKey}`, subjectShards);
       assignedVariation = variations.find((variation) =>
         isShardInRange(assignmentShard, variation.shardRange),

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -356,7 +356,7 @@ export default class EppoClient implements IEppoClient {
     let holdoutKey = null;
     let holdoutVariation = null;
 
-    if (this.isInHoldoutSample(subjectKey, flagKey, experimentConfig, holdout)) {
+    if (holdout && this.isInHoldoutSample(subjectKey, flagKey, experimentConfig, holdout)) {
       const { statusQuo, shipped, keys } = holdout;
       const holdoutShard = getShard(`holdout-assignment-${subjectKey}-${flagKey}`, subjectShards);
       let matchingHoldout = keys.find((key) =>

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -363,7 +363,11 @@ export default class EppoClient implements IEppoClient {
         assignedVariation = variations.find(
           (variation) => variation.variationKey === statusQuoVariationKey,
         );
-        holdoutVariation = 'status_quo';
+        // Only log the holdout variation if this is a rollout allocation
+        // Only rollout allocations have shippedShardRange specified
+        if (shippedShardRange) {
+          holdoutVariation = 'status_quo';
+        }
       } else if (shippedShardRange && isShardInRange(holdoutShard, shippedShardRange)) {
         assignedVariation = variations.find(
           (variation) => variation.variationKey === shippedVariationKey,

--- a/src/dto/allocation-dto.ts
+++ b/src/dto/allocation-dto.ts
@@ -4,5 +4,5 @@ import { IVariation } from './variation-dto';
 export interface IAllocation {
   percentExposure: number;
   variations: IVariation[];
-  holdout: IHoldout;
+  holdout: IHoldout | null;
 }

--- a/src/dto/allocation-dto.ts
+++ b/src/dto/allocation-dto.ts
@@ -4,5 +4,7 @@ import { IVariation } from './variation-dto';
 export interface IAllocation {
   percentExposure: number;
   variations: IVariation[];
-  holdout: IHoldout | null;
+  statusQuoVariationKey: string | null;
+  shippedVariationKey: string | null;
+  holdouts: IHoldout[];
 }

--- a/src/dto/allocation-dto.ts
+++ b/src/dto/allocation-dto.ts
@@ -1,6 +1,8 @@
+import { IHoldout } from './holdout-dto';
 import { IVariation } from './variation-dto';
 
 export interface IAllocation {
   percentExposure: number;
   variations: IVariation[];
+  holdout: IHoldout;
 }

--- a/src/dto/holdout-dto.ts
+++ b/src/dto/holdout-dto.ts
@@ -1,14 +1,7 @@
 import { IShardRange } from './variation-dto';
 
-interface IHoldoutKey {
+export interface IHoldout {
   statusQuoShardRange: IShardRange;
   shippedShardRange: IShardRange | null;
   holdoutKey: string;
-}
-
-export interface IHoldout {
-  statusQuo: string;
-  shipped: string | null;
-  percentExposure: number;
-  keys: IHoldoutKey[];
 }

--- a/src/dto/holdout-dto.ts
+++ b/src/dto/holdout-dto.ts
@@ -1,0 +1,14 @@
+import { IShardRange } from './variation-dto';
+
+interface IHoldoutKey {
+  statusQuoShardRange: IShardRange;
+  shippedShardRange: IShardRange | null;
+  holdoutKey: string;
+}
+
+export interface IHoldout {
+  statusQuo: string;
+  shipped: string | null;
+  percentExposure: number;
+  keys: IHoldoutKey[];
+}

--- a/src/dto/variation-dto.ts
+++ b/src/dto/variation-dto.ts
@@ -6,6 +6,7 @@ export interface IShardRange {
 }
 
 export interface IVariation {
+  variationKey: string;
   name: string;
   value: string;
   typedValue: IValue;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1293,13 +1293,14 @@ asynckit@^0.4.0:
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^0.27.2:
-  version "0.27.2"
-  resolved "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz"
-  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+axios@^1.6.0:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.2.tgz#de67d42c755b571d3e698df1b6504cde9b0ee9f2"
+  integrity sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==
   dependencies:
-    follow-redirects "^1.14.9"
+    follow-redirects "^1.15.0"
     form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-jest@^28.1.1:
   version "28.1.1"
@@ -2149,10 +2150,10 @@ flatted@^3.1.0:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
-follow-redirects@^1.14.9:
-  version "1.15.1"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz"
-  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+follow-redirects@^1.15.0:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
+  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
 
 form-data@^4.0.0:
   version "4.0.0"
@@ -3571,6 +3572,11 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.8.0"


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: [FF-1130](https://linear.app/eppo/issue/FF-1130/sdk-assigns-subjects-to-a-holdout-[js-common])

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

## Description
[//]: # (Describe your changes in detail)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

`yarn test`

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
