### PR TITLE
Gracefully handle if allocation has no holdouts field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -361,7 +361,7 @@ export default class EppoClient implements IEppoClient {
     let holdoutVariation = null;
 
     const holdoutShard = getShard(`holdout-${subjectKey}`, subjectShards);
-    const matchingHoldout = holdouts.find((holdout) => {
+    const matchingHoldout = holdouts?.find((holdout) => {
       const { statusQuoShardRange, shippedShardRange } = holdout;
       if (isShardInRange(holdoutShard, statusQuoShardRange)) {
         assignedVariation = variations.find(


### PR DESCRIPTION
**Ticket:** [FF-1291 - JavaScript SDK doesn't gracefully handle missing holdouts in the RAC](https://linear.app/eppo/issue/FF-1291/javascript-sdk-doesnt-gracefully-handle-missing-holdouts-in-the-rac)
[//]: #  (Link to the issue corresponding to this chunk of work)

## Motivation and Context
If an allocation doesn't have a `holdouts` array at all, it hits an error.

![image](https://github.com/Eppo-exp/js-client-sdk-common/assets/417605/ff8685d1-8a0d-4e92-be79-0b2faee4443b)

## How has this been tested?
* Adjusted test data used by unit tests
