### PR TITLE
Adds `useCustomAssignmentCache` function to allow upstream clients toinject their own implementation (FF-839)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "1.8.2",
+  "version": "2.0.0",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/assignment-cache.ts
+++ b/src/assignment-cache.ts
@@ -54,7 +54,7 @@ export abstract class AssignmentCache<T extends Cacheable> {
  * The primary use case is for client-side SDKs, where the cache is only used
  * for a single user.
  */
-export class NonExpiringAssignmentCache extends AssignmentCache<Map<string, string>> {
+export class NonExpiringInMemoryAssignmentCache extends AssignmentCache<Map<string, string>> {
   constructor() {
     super(new Map<string, string>());
   }
@@ -69,7 +69,7 @@ export class NonExpiringAssignmentCache extends AssignmentCache<Map<string, stri
  * multiple users. In this case, the cache size should be set to the maximum number
  * of users that can be active at the same time.
  */
-export class LRUAssignmentCache extends AssignmentCache<LRUCache<string, string>> {
+export class LRUInMemoryAssignmentCache extends AssignmentCache<LRUCache<string, string>> {
   constructor(maxSize: number) {
     super(new LRUCache<string, string>({ max: maxSize }));
   }

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -395,7 +395,7 @@ describe('EppoClient E2E test', () => {
     });
 
     it('does not log duplicate assignments', () => {
-      client.useNonExpiringAssignmentCache();
+      client.useNonExpiringInMemoryAssignmentCache();
 
       client.getAssignment('subject-10', flagKey);
       client.getAssignment('subject-10', flagKey);
@@ -405,7 +405,7 @@ describe('EppoClient E2E test', () => {
     });
 
     it('logs assignment again after the lru cache is full', () => {
-      client.useLRUAssignmentCache(2);
+      client.useLRUInMemoryAssignmentCache(2);
 
       client.getAssignment('subject-10', flagKey); // logged
       client.getAssignment('subject-10', flagKey); // cached
@@ -449,7 +449,7 @@ describe('EppoClient E2E test', () => {
         },
       });
 
-      client.useNonExpiringAssignmentCache();
+      client.useNonExpiringInMemoryAssignmentCache();
 
       client.getAssignment('subject-10', flagKey);
       client.getAssignment('subject-10', flagKey);
@@ -465,7 +465,7 @@ describe('EppoClient E2E test', () => {
     });
 
     it('logs twice for the same flag when rollout increases/flag changes', () => {
-      client.useNonExpiringAssignmentCache();
+      client.useNonExpiringInMemoryAssignmentCache();
 
       storage.setEntries({
         [flagKey]: {
@@ -540,7 +540,7 @@ describe('EppoClient E2E test', () => {
     });
 
     it('logs the same subject/flag/variation after two changes', () => {
-      client.useNonExpiringAssignmentCache();
+      client.useNonExpiringInMemoryAssignmentCache();
 
       // original configuration version
       storage.setEntries({ [flagKey]: mockExperimentConfig });

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -3,8 +3,8 @@ import * as md5 from 'md5';
 import {
   AssignmentCache,
   Cacheable,
-  LRUAssignmentCache,
-  NonExpiringAssignmentCache,
+  LRUInMemoryAssignmentCache,
+  NonExpiringInMemoryAssignmentCache,
 } from '../assignment-cache';
 import { IAssignmentHooks } from '../assignment-hooks';
 import {
@@ -418,12 +418,16 @@ export default class EppoClient implements IEppoClient {
     this.assignmentCache = undefined;
   }
 
-  public useNonExpiringAssignmentCache() {
-    this.assignmentCache = new NonExpiringAssignmentCache();
+  public useNonExpiringInMemoryAssignmentCache() {
+    this.assignmentCache = new NonExpiringInMemoryAssignmentCache();
   }
 
-  public useLRUAssignmentCache(maxSize: number) {
-    this.assignmentCache = new LRUAssignmentCache(maxSize);
+  public useLRUInMemoryAssignmentCache(maxSize: number) {
+    this.assignmentCache = new LRUInMemoryAssignmentCache(maxSize);
+  }
+
+  public useCustomAssignmentCache(cache: AssignmentCache<Cacheable>) {
+    this.assignmentCache = cache;
   }
 
   public setIsGracefulFailureMode(gracefulFailureMode: boolean) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { AssignmentCache } from './assignment-cache';
 import { IAssignmentHooks } from './assignment-hooks';
 import { IAssignmentLogger, IAssignmentEvent } from './assignment-logger';
 import EppoClient, { IEppoClient } from './client/eppo-client';
@@ -18,4 +19,5 @@ export {
   HttpClient,
   validation,
   IConfigurationStore,
+  AssignmentCache,
 };


### PR DESCRIPTION
… inject their own implementation (FF-839)

---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Eppo previously provided 2 implementations of the assignment cache in this library based on generic data structures: `Map` and `LRUCache`. These are non-persistent and cleared between user sessions causing a larger volume of assignment logging then desired.

The goal is to provide persistent cache implementations for our platforms on js browser and react native but these have different APIs: `LocalStorage` and `AsyncStorage`, respectively.

## Description
[//]: # (Describe your changes in detail)

* renaming existing implementations to include `InMemory` as part of the class name for clarity
* adding `useCustomAssignmentCache` will allow our `js-client` and `react-native` SDKs to add their own implementations.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
