### PR TITLE
Ability to set configuration request parameters on an already instantiated client instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -1160,9 +1160,22 @@ describe('Eppo Client constructed with configuration request parameters', () => 
     mock.teardown();
   });
 
-  it('Fetches initial configuration', async () => {
+  it('Fetches initial configuration with parameters in constructor', async () => {
     client = new EppoClient(storage, requestConfiguration);
     client.setIsGracefulFailureMode(false);
+    // no configuration loaded
+    let variation = client.getAssignment(subjectForGreenVariation, flagKey);
+    expect(variation).toBeNull();
+    // have client fetch configurations
+    await client.fetchFlagConfigurations();
+    variation = client.getAssignment(subjectForGreenVariation, flagKey);
+    expect(variation).toBe('green');
+  });
+
+  it('Fetches initial configuration with parameters provided later', async () => {
+    client = new EppoClient(storage);
+    client.setIsGracefulFailureMode(false);
+    client.setConfigurationRequestParameters(requestConfiguration);
     // no configuration loaded
     let variation = client.getAssignment(subjectForGreenVariation, flagKey);
     expect(variation).toBeNull();

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -165,7 +165,7 @@ export default class EppoClient implements IEppoClient {
   public async fetchFlagConfigurations() {
     if (!this.configurationRequestParameters) {
       throw new Error(
-        'Eppo SDK unable to fetch flag configurations without a configuration request parameters',
+        'Eppo SDK unable to fetch flag configurations without configuration request parameters',
       );
     }
 


### PR DESCRIPTION
🎟️  **Ticket:** _(Eppo Internal)_ [FF-1557 - JS Client SDK should return null when not initialized](https://linear.app/eppo/issue/FF-1557/js-client-sdk-should-return-null-when-not-initialized)
👯 **Related PR:** [`eppo-client-sdk` #48](https://github.com/Eppo-exp/js-client-sdk/pull/48)

## Motivation and Context
Using `EppoRandomizationProvider` without `waitForInitialization = true` or any other JavaScript pattern where initialization of the client is not `await`ed, could result in some `getInstance()` and `getAssignment()` calls on an uninitialized instance.

Previous changes to `js-client-sdk` made it so that it threw an error ([link](https://github.com/Eppo-exp/js-client-sdk/pull/45/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R218)). However, we want to revert to the behavior of returning `null,` which this PR does (but now with a warning) on calls to `getAssignment()`.

To accomplish this, we need to revert to having a default initialized instance ([link to where that was changed](https://github.com/Eppo-exp/js-client-sdk/pull/45/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L53)) that is later populated during initialization.

## Description
To allow upstream-created client instances to set configuration request parameters, we provide a new method: `setConfigurationRequestParameters()`.

I also renamed the internal variables to `configurationRequestParameters` to more consistent and not have "config" in them twice.

## How has this been tested?
* New test added to `eppo-client.spec.ts`
* This module was locally installed in the `js-client-sdk` and `node-server-sdk` repositories using `make prepare` and `yarn add --force --file:../js-client-sdk-common`
