### PR TITLE
Evaluate targeting rules with semver string format (FF-1433)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.11",
     "@types/md5": "^2.3.2",
+    "@types/semver": "^7.5.6",
     "@typescript-eslint/eslint-plugin": "^5.13.0",
     "@typescript-eslint/parser": "^5.13.0",
     "eslint": "^8.17.0",
@@ -65,6 +66,7 @@
   "dependencies": {
     "axios": "^1.6.0",
     "lru-cache": "^10.0.1",
-    "md5": "^2.3.0"
+    "md5": "^2.3.0",
+    "semver": "^7.5.4"
   }
 }

--- a/src/dto/rule-dto.ts
+++ b/src/dto/rule-dto.ts
@@ -8,6 +8,13 @@ export enum OperatorType {
   NOT_ONE_OF = 'NOT_ONE_OF',
 }
 
+export enum OperatorValueType {
+  PLAIN_STRING = 'PLAIN_STRING',
+  STRING_ARRAY = 'STRING_ARRAY',
+  SEM_VER = 'SEM_VER',
+  NUMERIC = 'NUMERIC',
+}
+
 export interface Condition {
   operator: OperatorType;
   attribute: string;

--- a/src/rule_evaluator.spec.ts
+++ b/src/rule_evaluator.spec.ts
@@ -21,6 +21,21 @@ describe('findMatchingRule', () => {
       },
     ],
   };
+  const semverRule: IRule = {
+    allocationKey: 'test',
+    conditions: [
+      {
+        operator: OperatorType.GTE,
+        attribute: 'version',
+        value: '1.0.0',
+      },
+      {
+        operator: OperatorType.LTE,
+        attribute: 'version',
+        value: '2.0.0',
+      },
+    ],
+  };
   const ruleWithMatchesCondition: IRule = {
     allocationKey: 'test',
     conditions: [
@@ -45,6 +60,13 @@ describe('findMatchingRule', () => {
   it('returns the rule if attributes match AND conditions', () => {
     const rules = [numericRule];
     expect(findMatchingRule({ totalSales: 100 }, rules, false)).toEqual(numericRule);
+  });
+
+  it('returns the rule for semver conditions', () => {
+    const rules = [semverRule];
+    expect(findMatchingRule({ version: '1.1.0' }, rules, false)).toEqual(semverRule);
+    expect(findMatchingRule({ version: '2.0.0' }, rules, false)).toEqual(semverRule);
+    expect(findMatchingRule({ version: '2.1.0' }, rules, false)).toBeNull();
   });
 
   it('returns null if there is no attribute for the condition', () => {

--- a/src/rule_evaluator.ts
+++ b/src/rule_evaluator.ts
@@ -53,30 +53,26 @@ function evaluateCondition(subjectAttributes: Record<string, any>, condition: Co
 
   const conditionValueType = targetingRuleConditionValuesTypesFromValues(condition.value);
 
-  // think: old clients will receive a string value for
-  // gt, gte, lt, lte when they are expecting a numeric.
-  // what will their behavior be?
-
   if (value != null) {
     switch (condition.operator) {
       case OperatorType.GTE:
         if (conditionValueType === OperatorValueType.SEM_VER) {
-          return compareSemVer(value, condition.value, (a, b) => semverGte(a, b));
+          return compareSemVer(value, condition.value, semverGte);
         }
         return compareNumber(value, condition.value, (a, b) => a >= b);
       case OperatorType.GT:
         if (conditionValueType === OperatorValueType.SEM_VER) {
-          return compareSemVer(value, condition.value, (a, b) => semverGt(a, b));
+          return compareSemVer(value, condition.value, semverGt);
         }
         return compareNumber(value, condition.value, (a, b) => a > b);
       case OperatorType.LTE:
         if (conditionValueType === OperatorValueType.SEM_VER) {
-          return compareSemVer(value, condition.value, (a, b) => semverLte(a, b));
+          return compareSemVer(value, condition.value, semverLte);
         }
         return compareNumber(value, condition.value, (a, b) => a <= b);
       case OperatorType.LT:
         if (conditionValueType === OperatorValueType.SEM_VER) {
-          return compareSemVer(value, condition.value, (a, b) => semverLt(a, b));
+          return compareSemVer(value, condition.value, semverLt);
         }
         return compareNumber(value, condition.value, (a, b) => a < b);
       case OperatorType.MATCHES:
@@ -111,22 +107,22 @@ function evaluateObfuscatedCondition(
     switch (condition.operator) {
       case getMD5Hash(OperatorType.GTE):
         if (conditionValueType === OperatorValueType.SEM_VER) {
-          return compareSemVer(value, decodeBase64(condition.value), (a, b) => semverGte(a, b));
+          return compareSemVer(value, decodeBase64(condition.value), semverGte);
         }
         return compareNumber(value, Number(decodeBase64(condition.value)), (a, b) => a >= b);
       case getMD5Hash(OperatorType.GT):
         if (conditionValueType === OperatorValueType.SEM_VER) {
-          return compareSemVer(value, decodeBase64(condition.value), (a, b) => semverGt(a, b));
+          return compareSemVer(value, decodeBase64(condition.value), semverGt);
         }
         return compareNumber(value, Number(decodeBase64(condition.value)), (a, b) => a > b);
       case getMD5Hash(OperatorType.LTE):
         if (conditionValueType === OperatorValueType.SEM_VER) {
-          return compareSemVer(value, decodeBase64(condition.value), (a, b) => semverLte(a, b));
+          return compareSemVer(value, decodeBase64(condition.value), semverLte);
         }
         return compareNumber(value, Number(decodeBase64(condition.value)), (a, b) => a <= b);
       case getMD5Hash(OperatorType.LT):
         if (conditionValueType === OperatorValueType.SEM_VER) {
-          return compareSemVer(value, decodeBase64(condition.value), (a, b) => semverLt(a, b));
+          return compareSemVer(value, decodeBase64(condition.value), semverLt);
         }
         return compareNumber(value, Number(decodeBase64(condition.value)), (a, b) => a < b);
       case getMD5Hash(OperatorType.MATCHES):

--- a/yarn.lock
+++ b/yarn.lock
@@ -786,6 +786,11 @@
   dependencies:
     undici-types "~5.26.4"
 
+"@types/semver@^7.5.6":
+  version "7.5.6"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.6.tgz#c65b2bfce1bec346582c07724e3f8c1017a20339"
+  integrity sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

RAC API will start returning targeting rule values containing semver strings (https://github.com/Eppo-exp/eppo/pull/8697).

Our SDKs need to be able to parse these strings and perform rule evaluation on them.

## Description
[//]: # (Describe your changes in detail)

The operations `lt, gt, lte, gte` now only apply to numeric values; insert a higher priority step to check if the value is a semver string; if so apply the comparison with it. Otherwise fall through and attempt to evaluate using numerics.

**behavior of un-upgraded SDKs**

They will continue to assume that only numeric values will be present for the `lt, gt, lte, gte` operations - the `compareNumber` function will return false if both sides of the comparison are not numbers.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

New unit tests.

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
