### PR TITLE
enable providing subject attributes as string wrapper numerics to be …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/rule_evaluator.spec.ts
+++ b/src/rule_evaluator.spec.ts
@@ -78,11 +78,6 @@ describe('findMatchingRule', () => {
     ).toEqual(null);
   });
 
-  it('allows for numeric comparison with string', () => {
-    const rules = [numericRule];
-    expect(findMatchingRule({ totalSales: '100' }, rules, false)).toEqual(numericRule);
-  });
-
   it('returns the rule if attributes match AND conditions', () => {
     const rules = [numericRule];
     expect(findMatchingRule({ totalSales: 100 }, rules, false)).toEqual(numericRule);
@@ -105,10 +100,10 @@ describe('findMatchingRule', () => {
     expect(findMatchingRule({ totalSales: 101 }, rules, false)).toEqual(ruleWithEmptyConditions);
   });
 
-  it('returns null if using numeric operator with string', () => {
+  it('allows for a mix of numeric and string values', () => {
     const rules = [numericRule, ruleWithMatchesCondition];
     expect(findMatchingRule({ totalSales: 'stringValue' }, rules, false)).toEqual(null);
-    expect(findMatchingRule({ totalSales: '20' }, rules, false)).toEqual(null);
+    expect(findMatchingRule({ totalSales: '20' }, rules, false)).toEqual(numericRule);
   });
 
   it('handles rule with matches operator', () => {

--- a/src/rule_evaluator.spec.ts
+++ b/src/rule_evaluator.spec.ts
@@ -55,6 +55,32 @@ describe('findMatchingRule', () => {
   it('returns null if attributes do not match any rules', () => {
     const rules = [numericRule];
     expect(findMatchingRule({ totalSales: 101 }, rules, false)).toEqual(null);
+
+    // input subject attribute is a string which is not a valid semver nor numeric
+    // verify that is not parsed to a semver nor a numeric.
+    expect(
+      findMatchingRule(
+        { version: '1.2.03' },
+        [
+          {
+            allocationKey: 'test',
+            conditions: [
+              {
+                operator: OperatorType.GTE,
+                attribute: 'version',
+                value: '1.2.0',
+              },
+            ],
+          },
+        ],
+        false,
+      ),
+    ).toEqual(null);
+  });
+
+  it('allows for numeric comparison with string', () => {
+    const rules = [numericRule];
+    expect(findMatchingRule({ totalSales: '100' }, rules, false)).toEqual(numericRule);
   });
 
   it('returns the rule if attributes match AND conditions', () => {

--- a/src/rule_evaluator.ts
+++ b/src/rule_evaluator.ts
@@ -153,11 +153,7 @@ function compareNumber(
   conditionValue: any,
   compareFn: (a: number, b: number) => boolean,
 ): boolean {
-  return (
-    typeof attributeValue === 'number' &&
-    typeof conditionValue === 'number' &&
-    compareFn(attributeValue, conditionValue)
-  );
+  return compareFn(Number(attributeValue), Number(conditionValue));
 }
 
 function compareSemVer(


### PR DESCRIPTION
…evaluated against numeric rules (FF-1661)

---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Consistent behavior with other SDKs allows users to provide a string wrapper numeric.

```
subjectAttributes := make(map[string]interface{})
subjectAttributes["platform"] = "android"
subjectAttributes["app_version"] = "2" // <== compare this against the number `2`
```

## Description
[//]: # (Describe your changes in detail)

Instead of checking for a type match, coerce the incoming value with `Number(..)` to allow for a mix of `number` and `string` types to be compared against each other.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

New unit tests.

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
