### PR TITLE
Replace lru-cache package with simple local implementation (FF-1876)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [
@@ -65,7 +65,6 @@
   },
   "dependencies": {
     "axios": "^1.6.0",
-    "lru-cache": "^10.0.1",
     "md5": "^2.3.0",
     "pino": "^8.19.0",
     "semver": "^7.5.4",

--- a/src/assignment-cache.ts
+++ b/src/assignment-cache.ts
@@ -1,6 +1,5 @@
-import { LRUCache } from 'lru-cache';
-
 import { EppoValue } from './eppo_value';
+import { LRUCache } from './lru-cache';
 
 export interface AssignmentCacheKey {
   subjectKey: string;
@@ -69,8 +68,8 @@ export class NonExpiringInMemoryAssignmentCache extends AssignmentCache<Map<stri
  * multiple users. In this case, the cache size should be set to the maximum number
  * of users that can be active at the same time.
  */
-export class LRUInMemoryAssignmentCache extends AssignmentCache<LRUCache<string, string>> {
+export class LRUInMemoryAssignmentCache extends AssignmentCache<LRUCache> {
   constructor(maxSize: number) {
-    super(new LRUCache<string, string>({ max: maxSize }));
+    super(new LRUCache(maxSize));
   }
 }

--- a/src/lru-cache.spec.ts
+++ b/src/lru-cache.spec.ts
@@ -1,0 +1,64 @@
+import { LRUCache } from './lru-cache';
+
+describe('LRUCache', () => {
+  let cache: LRUCache;
+
+  beforeEach(() => {
+    cache = new LRUCache(2);
+  });
+
+  it('should insert and retrieve a value', () => {
+    cache.set('a', 'apple');
+    expect(cache.get('a')).toBe('apple');
+  });
+
+  it('should return undefined for missing values', () => {
+    expect(cache.get('missing')).toBeUndefined();
+  });
+
+  it('should overwrite existing values', () => {
+    cache.set('a', 'apple');
+    cache.set('a', 'avocado');
+    expect(cache.get('a')).toBe('avocado');
+  });
+
+  it('should evict least recently used item', () => {
+    cache.set('a', 'apple');
+    cache.set('b', 'banana');
+    cache.set('c', 'cherry');
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toBe('banana');
+    expect(cache.get('c')).toBe('cherry');
+  });
+
+  it('should move recently used item to the end of the cache', () => {
+    cache.set('a', 'apple');
+    cache.set('b', 'banana');
+    cache.get('a'); // Access 'a' to make it recently used
+    cache.set('c', 'cherry');
+    expect(cache.get('a')).toBe('apple');
+    expect(cache.get('b')).toBeUndefined();
+    expect(cache.get('c')).toBe('cherry');
+  });
+
+  it('should check if a key exists', () => {
+    cache.set('a', 'apple');
+    expect(cache.has('a')).toBeTruthy();
+    expect(cache.has('b')).toBeFalsy();
+  });
+
+  it('should handle the cache capacity of zero', () => {
+    const zeroCache = new LRUCache(0);
+    zeroCache.set('a', 'apple');
+    expect(zeroCache.get('a')).toBeUndefined();
+  });
+
+  it('should handle the cache capacity of one', () => {
+    const oneCache = new LRUCache(1);
+    oneCache.set('a', 'apple');
+    expect(oneCache.get('a')).toBe('apple');
+    oneCache.set('b', 'banana');
+    expect(oneCache.get('a')).toBeUndefined();
+    expect(oneCache.get('b')).toBe('banana');
+  });
+});

--- a/src/lru-cache.ts
+++ b/src/lru-cache.ts
@@ -1,0 +1,60 @@
+/**
+ * LRUCache is a cache that stores a maximum number of items.
+ *
+ * Items are removed from the cache when the cache is full.
+ *
+ * The cache is implemented as a Map, which is a built-in JavaScript object.
+ * The Map object holds key-value pairs and remembers the order of key-value pairs as they were inserted.
+ */
+export class LRUCache {
+  private capacity: number;
+  private cache: Map<string, string>;
+
+  constructor(capacity: number) {
+    this.capacity = capacity;
+    this.cache = new Map<string, string>();
+  }
+
+  has(key: string): boolean {
+    return this.cache.has(key);
+  }
+
+  get(key: string): string | undefined {
+    if (!this.cache.has(key)) {
+      return undefined;
+    }
+
+    const value = this.cache.get(key);
+
+    if (value !== undefined) {
+      // the delete and set operations are used together to ensure that the most recently accessed
+      // or added item is always considered the "newest" in terms of access order.
+      // This is crucial for maintaining the correct order of elements in the cache,
+      // which directly impacts which item is considered the least recently used (LRU) and
+      // thus eligible for eviction when the cache reaches its capacity.
+      this.cache.delete(key);
+      this.cache.set(key, value);
+    }
+
+    return value;
+  }
+
+  set(key: string, value: string): void {
+    if (this.capacity === 0) {
+      return;
+    }
+
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
+    } else if (this.cache.size >= this.capacity) {
+      // To evict the least recently used (LRU) item, we retrieve the first key in the Map.
+      // This is possible because the Map object in JavaScript maintains the insertion order of the keys.
+      // Therefore, the first key represents the oldest entry, which is the least recently used item in our cache.
+      // We use Map.prototype.keys().next().value to obtain this oldest key and then delete it from the cache.
+      const oldestKey = this.cache.keys().next().value;
+      this.cache.delete(oldestKey);
+    }
+
+    this.cache.set(key, value);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3116,11 +3116,6 @@ lodash@^4.17.21:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-lru-cache@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz"
-  integrity sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==
-
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz"


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

A customer is unable to upgrade eppo's latest js sdk versions. 

```
ERROR in ./node_modules/@eppo/js-client-sdk-common/node_modules/lru-cache/dist/commonjs/index.js 27:15
Module parse failed: Unexpected token (27:15)
```

The `lru-cache` package appears to be incompatible for some reason.

## Description
[//]: # (Describe your changes in detail)

Replaces the package with a simple local implementation. Are needs do not require generic types, just a `Map<string, string>` suffices.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

New unit test for `LRUCache` class.

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
