### PR TITLE
Add isExpired method to IConfigurationStore (FF-1980)

### DIFF
--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -190,7 +190,12 @@ export default class EppoClient implements IEppoClient {
 
     this.requestPoller = initPoller(
       POLL_INTERVAL_MS,
-      configurationRequestor.fetchAndStoreConfigurations.bind(configurationRequestor),
+      async () => {
+        // If the configuration store is expired, we refetch the configurations
+        if (this.configurationStore.isExpired()) {
+          await configurationRequestor.fetchAndStoreConfigurations();
+        }
+      },
       {
         maxStartRetries:
           this.configurationRequestParameters.numInitialRequestRetries ??

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -525,6 +525,10 @@ export default class EppoClient implements IEppoClient {
     this.flushQueuedEvents(); // log any events that may have been queued while initializing
   }
 
+  public setConfigurationStore(configurationStore: IConfigurationStore) {
+    this.configurationStore = configurationStore;
+  }
+
   /**
    * Assignment cache methods.
    */

--- a/src/configuration-store.ts
+++ b/src/configuration-store.ts
@@ -1,4 +1,5 @@
 export interface IConfigurationStore {
   get<T>(key: string): T;
   setEntries<T>(entries: Record<string, T>): void;
+  isExpired(): boolean;
 }


### PR DESCRIPTION
## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

We need to add the ability to block configuration updating when the store is determined to be not expired - this will happen if an implementation is provided such that not enough time has elapsed for a refetch to happen. The customer improvement will be for extremely short-lived sessions, such as those in a chrome extension, that are invoked repeatedly the customer won't incur CDN request charges.

We need to publish a change to the `IConfigurationStore` interface in the `1.y.z` branch. A follow-up change will publish in the `3.y.z` branch (main).

## Description
[//]: # (Describe your changes in detail)

* Adds `isExpired: boolean` method to `IConfigurationStore`
* Augments the callback function of the poller that periodically fetches the configuration with a conditional check on the store being expired.
* Adds a unit test to verify that for a non-expired cache the request is not made.

👉 Related PR in `js-client-sdk` that will use this change: https://github.com/Eppo-exp/js-client-sdk/pull/57

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
