### PR TITLE
Make all typed assignment getters explicitly public

### DIFF
--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -211,7 +211,7 @@ export default class EppoClient implements IEppoClient {
     );
   }
 
-  getBoolAssignment(
+  public getBoolAssignment(
     flagKey: string,
     subjectKey: string,
     subjectAttributes: Record<string, AttributeType>,
@@ -228,7 +228,7 @@ export default class EppoClient implements IEppoClient {
     );
   }
 
-  getIntegerAssignment(
+  public getIntegerAssignment(
     flagKey: string,
     subjectKey: string,
     subjectAttributes: Record<string, AttributeType>,
@@ -245,7 +245,7 @@ export default class EppoClient implements IEppoClient {
     );
   }
 
-  getNumericAssignment(
+  public getNumericAssignment(
     flagKey: string,
     subjectKey: string,
     subjectAttributes: Record<string, AttributeType>,


### PR DESCRIPTION
---
labels: mergeable
---
No change in functionality. The typed assignment getters should all be explicitly marked as public, for readability.
