### PR TITLE
Replaced axios with fetch (FF-1976)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [
@@ -60,11 +60,9 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4",
     "webpack": "^5.73.0",
-    "webpack-cli": "^4.10.0",
-    "xhr-mock": "^2.5.1"
+    "webpack-cli": "^4.10.0"
   },
   "dependencies": {
-    "axios": "^1.6.0",
     "md5": "^2.3.0",
     "pino": "^8.19.0",
     "semver": "^7.5.4",

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -1,5 +1,3 @@
-import axios from 'axios';
-
 import {
   AssignmentCache,
   Cacheable,
@@ -19,8 +17,8 @@ import {
 import { decodeFlag } from '../decoding';
 import { EppoValue } from '../eppo_value';
 import { Evaluator, FlagEvaluation, noneResult } from '../evaluator';
-import ExperimentConfigurationRequestor from '../flag-configuration-requestor';
-import HttpClient from '../http-client';
+import FlagConfigurationRequestor from '../flag-configuration-requestor';
+import FetchHttpClient from '../http-client';
 import { Flag, ObfuscatedFlag, VariationType } from '../interfaces';
 import { getMD5Hash } from '../obfuscation';
 import initPoller, { IPoller } from '../poller';
@@ -152,16 +150,17 @@ export default class EppoClient implements IEppoClient {
       this.requestPoller.stop();
     }
 
-    const axiosInstance = axios.create({
-      baseURL: this.configurationRequestParameters.baseUrl || DEFAULT_BASE_URL,
-      timeout: this.configurationRequestParameters.requestTimeoutMs || DEFAULT_REQUEST_TIMEOUT_MS,
-    });
-    const httpClient = new HttpClient(axiosInstance, {
-      apiKey: this.configurationRequestParameters.apiKey,
-      sdkName: this.configurationRequestParameters.sdkName,
-      sdkVersion: this.configurationRequestParameters.sdkVersion,
-    });
-    const configurationRequestor = new ExperimentConfigurationRequestor(
+    // todo: consider injecting the IHttpClient interface
+    const httpClient = new FetchHttpClient(
+      this.configurationRequestParameters.baseUrl || DEFAULT_BASE_URL,
+      {
+        apiKey: this.configurationRequestParameters.apiKey,
+        sdkName: this.configurationRequestParameters.sdkName,
+        sdkVersion: this.configurationRequestParameters.sdkVersion,
+      },
+      this.configurationRequestParameters.requestTimeoutMs || DEFAULT_REQUEST_TIMEOUT_MS,
+    );
+    const configurationRequestor = new FlagConfigurationRequestor(
       this.configurationStore,
       httpClient,
     );

--- a/src/flag-configuration-requestor.ts
+++ b/src/flag-configuration-requestor.ts
@@ -1,5 +1,5 @@
 import { IConfigurationStore } from './configuration-store';
-import HttpClient from './http-client';
+import { IHttpClient } from './http-client';
 import { Flag } from './interfaces';
 
 const UFC_ENDPOINT = '/flag-config/v1/config';
@@ -9,7 +9,7 @@ interface IUniversalFlagConfig {
 }
 
 export default class FlagConfigurationRequestor {
-  constructor(private configurationStore: IConfigurationStore, private httpClient: HttpClient) {}
+  constructor(private configurationStore: IConfigurationStore, private httpClient: IHttpClient) {}
 
   async fetchAndStoreConfigurations(): Promise<Record<string, Flag>> {
     const responseData = await this.httpClient.get<IUniversalFlagConfig>(UFC_ENDPOINT);

--- a/src/http-client.spec.ts
+++ b/src/http-client.spec.ts
@@ -1,0 +1,84 @@
+import FetchHttpClient, { HttpRequestError, ISdkParams } from './http-client';
+
+describe('FetchHttpClient', () => {
+  const baseUrl = 'http://api.example.com';
+  const sdkParams: ISdkParams = {
+    apiKey: '12345',
+    sdkVersion: '1.0',
+    sdkName: 'ExampleSDK',
+  };
+  const timeout = 5000; // 5 seconds
+
+  let httpClient: FetchHttpClient;
+
+  beforeEach(() => {
+    httpClient = new FetchHttpClient(baseUrl, sdkParams, timeout);
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return data successfully when HTTP status is 200', async () => {
+    const mockJsonPromise = Promise.resolve({ data: 'test' });
+    const mockFetchPromise = Promise.resolve({
+      ok: true,
+      json: () => mockJsonPromise,
+      status: 200,
+    });
+    (global.fetch as jest.Mock).mockImplementation(() => mockFetchPromise);
+
+    const resource = '/data';
+    const result = await httpClient.get(resource);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${baseUrl}${resource}?apiKey=12345&sdkVersion=1.0&sdkName=ExampleSDK`,
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(result).toEqual({ data: 'test' });
+  });
+
+  it('should throw HttpRequestError when HTTP status is not 200', async () => {
+    const mockFetchPromise = Promise.resolve({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    });
+    (global.fetch as jest.Mock).mockImplementation(() => mockFetchPromise);
+
+    const resource = '/data';
+    await expect(httpClient.get(resource)).rejects.toThrow(HttpRequestError);
+    await expect(httpClient.get(resource)).rejects.toEqual(
+      new HttpRequestError('Failed to fetch data', 404),
+    );
+  });
+
+  it('should throw HttpRequestError on timeout', async () => {
+    jest.useFakeTimers();
+
+    (global.fetch as jest.Mock).mockImplementation(
+      () =>
+        // This promise rejects with a DOMException named AbortError after 10 seconds to simulate a timeout
+        // https://developer.chrome.com/blog/abortable-fetch/#reacting_to_an_aborted_fetch
+        new Promise((resolve, reject) =>
+          setTimeout(
+            () => reject(new DOMException('The operation was aborted.', 'AbortError')),
+            10000,
+          ),
+        ),
+    );
+
+    const resource = '/data';
+    const getPromise = httpClient.get(resource);
+
+    // Immediately advance the timers by 10 seconds to simulate the timeout
+    jest.advanceTimersByTime(10000);
+
+    await expect(getPromise).rejects.toThrow(HttpRequestError);
+    await expect(getPromise).rejects.toEqual(new HttpRequestError('Request timed out', 408));
+
+    jest.useRealTimers();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1187,15 +1187,6 @@ atomic-sleep@^1.0.0:
   resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
   integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
 
-axios@^1.6.0:
-  version "1.6.2"
-  resolved "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz"
-  integrity sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==
-  dependencies:
-    follow-redirects "^1.15.0"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
-
 babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz"
@@ -2071,11 +2062,6 @@ flatted@^3.1.0:
   version "3.2.5"
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
-
-follow-redirects@^1.15.0:
-  version "1.15.6"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
-  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
 form-data@^4.0.0:
   version "4.0.0"
@@ -3530,11 +3516,6 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
-
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1611,11 +1611,6 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-walk@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz"
-  integrity sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==
-
 domexception@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz"
@@ -2174,14 +2169,6 @@ glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-global@^4.3.0:
-  version "4.4.0"
-  resolved "https://registry.npmjs.org/global/-/global-4.4.0.tgz"
-  integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==
-  dependencies:
-    min-document "^2.19.0"
-    process "^0.11.10"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -3179,13 +3166,6 @@ mimic-fn@^2.1.0:
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-min-document@^2.19.0:
-  version "2.19.0"
-  resolved "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz"
-  integrity sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==
-  dependencies:
-    dom-walk "^0.1.0"
-
 minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
@@ -3522,11 +3502,6 @@ psl@^1.1.33:
   resolved "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
 
-punycode@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-  integrity sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==
-
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
@@ -3536,11 +3511,6 @@ pure-rand@^6.0.0:
   version "6.0.4"
   resolved "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz"
   integrity sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==
-
-querystring@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
-  integrity sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==
 
 querystringify@^2.1.1:
   version "2.2.0"
@@ -4168,14 +4138,6 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
-url@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.npmjs.org/url/-/url-0.11.0.tgz"
-  integrity sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==
-  dependencies:
-    punycode "1.3.2"
-    querystring "0.2.0"
-
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz"
@@ -4357,14 +4319,6 @@ ws@^8.11.0:
   version "8.16.0"
   resolved "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz"
   integrity sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==
-
-xhr-mock@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.npmjs.org/xhr-mock/-/xhr-mock-2.5.1.tgz"
-  integrity sha512-UKOjItqjFgPUwQGPmRAzNBn8eTfIhcGjBVGvKYAWxUQPQsXNGD6KEckGTiHwyaAUp9C9igQlnN1Mp79KWCg7CQ==
-  dependencies:
-    global "^4.3.0"
-    url "^0.11.0"
 
 xml-name-validator@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

1️⃣  the `axios` package cannot be supported in chrome extensions v3 because it is based on APIs that do not exist within a service worker. dogfooding eppo's js sdk within an v3 extension throws this error:

```
http-client.js:32 Uncaught (in promise) Error: There is no suitable adapter to dispatch the request since :
- adapter xhr is not supported by the environment
- adapter http is not available in the build
    at HttpClient.handleHttpError (http-client.js:32:1)
    at HttpClient.get (http-client.js:25:1)
    at async ExperimentConfigurationRequestor.fetchAndStoreConfigurations (experiment-configura…n-requestor.js:10:1)
    at async Object.start (poller.js:22:1)
    at async EppoJSClient.fetchFlagConfigurations (eppo-client.js:52:1)
    at async init (index.js:90:1)
    at async index.js:12:1
Show 2 more frames
```

2️⃣ `axios` is a heavy weight package and is something like 50% of our asset size. removing it will improve our customers' applications

## Description
[//]: # (Describe your changes in detail)

* replace `axios` with `fetch` - supporting a base url and timeouts
* adds `IHttpClient` interface and implementing `FetchHttpClient`

```
➜  js-client-sdk-common git:(lr/ff-1976/axios-fetch) yarn why axios
yarn why v1.22.22
[1/4] 🤔  Why do we have the module "axios"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
error We couldn't find a match!
✨  Done in 0.11s.
```

## Decisions

Since the `HttpClient` is instantiated inside the `EppoClient`, instead of being injected in, I have no choice but to continue mocking the http API. Changing from `xhr-mock` to mocking `fetch` itself. In the future if we decide passing the http client is useful then we can mock that object directly.

👉 Could use a set of eyes on the `beforeAlls` in the unit tests - everything passes but something feels a little off to me.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
