### PR TITLE
Convert IConfigurationStore to IAsyncWriteSyncReadStore (FF-1980)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "dependencies": {
     "md5": "^2.3.0",
     "pino": "^8.19.0",
+    "pino-pretty": "^11.0.0",
     "semver": "^7.5.4",
     "universal-base64": "^2.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
   "dependencies": {
     "md5": "^2.3.0",
     "pino": "^8.19.0",
-    "pino-pretty": "^11.0.0",
     "semver": "^7.5.4",
     "universal-base64": "^2.1.0"
   }

--- a/src/application-logger.ts
+++ b/src/application-logger.ts
@@ -1,5 +1,7 @@
 import pino from 'pino';
 
+export const loggerPrefix = '[Eppo SDK]';
+
 // Create a Pino logger instance
 export const logger = pino({
   level: process.env.NODE_ENV === 'production' ? 'warn' : 'info',

--- a/src/application-logger.ts
+++ b/src/application-logger.ts
@@ -1,8 +1,18 @@
 import pino from 'pino';
+import pretty from 'pino-pretty';
+
+const prettyStream = pretty({
+  translateTime: true,
+  ignore: 'pid,hostname',
+  messageFormat: '[Eppo SDK] {msg}',
+});
 
 // Create a Pino logger instance
-export const logger = pino({
-  level: process.env.NODE_ENV === 'production' ? 'warn' : 'info',
-  // https://getpino.io/#/docs/browser
-  browser: { disabled: true },
-});
+export const logger = pino(
+  {
+    level: process.env.NODE_ENV === 'production' ? 'warn' : 'info',
+    // https://getpino.io/#/docs/browser
+    browser: { disabled: true },
+  },
+  prettyStream,
+);

--- a/src/application-logger.ts
+++ b/src/application-logger.ts
@@ -1,18 +1,8 @@
 import pino from 'pino';
-import pretty from 'pino-pretty';
-
-const prettyStream = pretty({
-  translateTime: true,
-  ignore: 'pid,hostname',
-  messageFormat: '[Eppo SDK] {msg}',
-});
 
 // Create a Pino logger instance
-export const logger = pino(
-  {
-    level: process.env.NODE_ENV === 'production' ? 'warn' : 'info',
-    // https://getpino.io/#/docs/browser
-    browser: { disabled: true },
-  },
-  prettyStream,
-);
+export const logger = pino({
+  level: process.env.NODE_ENV === 'production' ? 'warn' : 'info',
+  // https://getpino.io/#/docs/browser
+  browser: { disabled: true },
+});

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -5,7 +5,7 @@ import {
   NonExpiringInMemoryAssignmentCache,
 } from '../assignment-cache';
 import { IAssignmentEvent, IAssignmentLogger } from '../assignment-logger';
-import { IConfigurationStore } from '../configuration-store';
+import { IConfigurationStore } from '../configuration-store/configuration-store';
 import {
   BASE_URL as DEFAULT_BASE_URL,
   DEFAULT_INITIAL_CONFIG_REQUEST_RETRIES,
@@ -116,13 +116,13 @@ export default class EppoClient implements IEppoClient {
   private isGracefulFailureMode = true;
   private isObfuscated = false;
   private assignmentCache: AssignmentCache<Cacheable> | undefined;
-  private configurationStore: IConfigurationStore;
+  private configurationStore: IConfigurationStore<Flag | ObfuscatedFlag>;
   private configurationRequestParameters: FlagConfigurationRequestParameters | undefined;
   private requestPoller: IPoller | undefined;
   private evaluator: Evaluator;
 
   constructor(
-    configurationStore: IConfigurationStore,
+    configurationStore: IConfigurationStore<Flag | ObfuscatedFlag>,
     configurationRequestParameters?: FlagConfigurationRequestParameters,
     obfuscated = false,
   ) {
@@ -387,7 +387,9 @@ export default class EppoClient implements IEppoClient {
   }
 
   private getObfuscatedFlag(flagKey: string): Flag | null {
-    const flag: ObfuscatedFlag | null = this.configurationStore.get(getMD5Hash(flagKey));
+    const flag: ObfuscatedFlag | null = this.configurationStore.get(
+      getMD5Hash(flagKey),
+    ) as ObfuscatedFlag;
     return flag ? decodeFlag(flag) : null;
   }
 

--- a/src/configuration-store.ts
+++ b/src/configuration-store.ts
@@ -1,6 +1,0 @@
-export interface IConfigurationStore {
-  get<T>(key: string): T;
-  getKeys(): string[];
-  setEntries<T>(entries: Record<string, T>): void;
-  isInitialized(): boolean;
-}

--- a/src/configuration-store/configuration-store.ts
+++ b/src/configuration-store/configuration-store.ts
@@ -1,0 +1,45 @@
+/**
+ * ConfigurationStore interface
+ *
+ * The interface guides implementation
+ * of a policy for handling a mixture of async and sync storage.
+ *
+ * The goal is to support remote API responses to be written to the sync and async store,
+ * while also supporting reading from the sync store to maintain public SDK APIs.
+ *
+ * Implementation is handled in upstream libraries to best support their use case, some ideas:
+ *
+ * - Javascript frontend:
+ *   - SyncStore: backed by localStorage
+ *   - AsyncStore: backed by IndexedDB or chrome.storage.local
+ *
+ * - NodeJS backend:
+ *   - SyncStore: backed by LRU cache
+ *   - AsyncStore: none
+ *
+ * The policy choices surrounding the use of one or more underlying storages are
+ * implementation specific and handled upstream.
+ */
+export interface IConfigurationStore<T> {
+  servingStore: ISyncStore<T>;
+  persistentStore: IAsyncStore<T> | null;
+
+  init(): Promise<void>;
+  get(key: string): T;
+  getKeys(): string[];
+  isInitialized(): boolean;
+  setEntries(entries: Record<string, T>): Promise<void>;
+}
+
+export interface ISyncStore<T> {
+  get(key: string): T;
+  getKeys(): string[];
+  isInitialized(): boolean;
+  setEntries(entries: Record<string, T>): void;
+}
+
+export interface IAsyncStore<T> {
+  isInitialized(): boolean;
+  getEntries(): Promise<Record<string, T>>;
+  setEntries(entries: Record<string, T>): Promise<void>;
+}

--- a/src/configuration-store/configuration-store.ts
+++ b/src/configuration-store/configuration-store.ts
@@ -25,14 +25,14 @@ export interface IConfigurationStore<T> {
   persistentStore: IAsyncStore<T> | null;
 
   init(): Promise<void>;
-  get(key: string): T;
+  get(key: string): T | null;
   getKeys(): string[];
   isInitialized(): boolean;
   setEntries(entries: Record<string, T>): Promise<void>;
 }
 
 export interface ISyncStore<T> {
-  get(key: string): T;
+  get(key: string): T | null;
   getKeys(): string[];
   isInitialized(): boolean;
   setEntries(entries: Record<string, T>): void;

--- a/src/configuration-store/hybrid.store.spec.ts
+++ b/src/configuration-store/hybrid.store.spec.ts
@@ -1,0 +1,70 @@
+import { IAsyncStore, ISyncStore } from './configuration-store';
+import { HybridConfigurationStore } from './hybrid.store';
+describe('HybridConfigurationStore', () => {
+  let syncStoreMock: ISyncStore<string>;
+  let asyncStoreMock: IAsyncStore<string>;
+  let store: HybridConfigurationStore<string>;
+
+  beforeEach(() => {
+    syncStoreMock = {
+      get: jest.fn(),
+      getKeys: jest.fn(),
+      isInitialized: jest.fn(),
+      setEntries: jest.fn(),
+    };
+
+    asyncStoreMock = {
+      getEntries: jest.fn(),
+      isInitialized: jest.fn(),
+      setEntries: jest.fn(),
+    };
+
+    store = new HybridConfigurationStore(syncStoreMock, asyncStoreMock);
+  });
+
+  describe('init', () => {
+    it('should initialize the serving store with entries from the persistent store if the persistent store is initialized', async () => {
+      const entries = { key1: 'value1', key2: 'value2' };
+      (asyncStoreMock.isInitialized as jest.Mock).mockReturnValue(true);
+      (asyncStoreMock.getEntries as jest.Mock).mockResolvedValue(entries);
+
+      await store.init();
+
+      expect(syncStoreMock.setEntries).toHaveBeenCalledWith(entries);
+    });
+  });
+
+  describe('isInitialized', () => {
+    it('should return true if both stores are initialized', () => {
+      (syncStoreMock.isInitialized as jest.Mock).mockReturnValue(true);
+      (asyncStoreMock.isInitialized as jest.Mock).mockReturnValue(true);
+
+      expect(store.isInitialized()).toBe(true);
+    });
+
+    it('should return false if either store is not initialized', () => {
+      (syncStoreMock.isInitialized as jest.Mock).mockReturnValue(false);
+      (asyncStoreMock.isInitialized as jest.Mock).mockReturnValue(true);
+
+      expect(store.isInitialized()).toBe(false);
+    });
+  });
+
+  describe('setEntries', () => {
+    it('should set entries in both stores if the persistent store is present', async () => {
+      const entries = { key1: 'value1', key2: 'value2' };
+      await store.setEntries(entries);
+
+      expect(asyncStoreMock.setEntries).toHaveBeenCalledWith(entries);
+      expect(syncStoreMock.setEntries).toHaveBeenCalledWith(entries);
+    });
+
+    it('should only set entries in the serving store if the persistent store is null', async () => {
+      const mixedStoreWithNull = new HybridConfigurationStore(syncStoreMock, null);
+      const entries = { key1: 'value1', key2: 'value2' };
+      await mixedStoreWithNull.setEntries(entries);
+
+      expect(syncStoreMock.setEntries).toHaveBeenCalledWith(entries);
+    });
+  });
+});

--- a/src/configuration-store/hybrid.store.spec.ts
+++ b/src/configuration-store/hybrid.store.spec.ts
@@ -1,5 +1,6 @@
 import { IAsyncStore, ISyncStore } from './configuration-store';
 import { HybridConfigurationStore } from './hybrid.store';
+
 describe('HybridConfigurationStore', () => {
   let syncStoreMock: ISyncStore<string>;
   let asyncStoreMock: IAsyncStore<string>;

--- a/src/configuration-store/hybrid.store.ts
+++ b/src/configuration-store/hybrid.store.ts
@@ -1,4 +1,4 @@
-import { logger } from '../application-logger';
+import { logger, loggerPrefix } from '../application-logger';
 
 import { IAsyncStore, IConfigurationStore, ISyncStore } from './configuration-store';
 
@@ -28,7 +28,7 @@ export class HybridConfigurationStore<T> implements IConfigurationStore<T> {
        * may be stale.
        */
       logger.warn(
-        'Persistent store is not initialized from remote configuration. Serving assignments that may be stale.',
+        `${loggerPrefix} Persistent store is not initialized from remote configuration. Serving assignments that may be stale.`,
       );
     }
 
@@ -42,7 +42,7 @@ export class HybridConfigurationStore<T> implements IConfigurationStore<T> {
 
   public get(key: string): T | null {
     if (!this.servingStore.isInitialized()) {
-      logger.warn('getting a value from a ServingStore that is not initialized.');
+      logger.warn(`${loggerPrefix} getting a value from a ServingStore that is not initialized.`);
     }
     return this.servingStore.get(key);
   }

--- a/src/configuration-store/hybrid.store.ts
+++ b/src/configuration-store/hybrid.store.ts
@@ -40,7 +40,7 @@ export class HybridConfigurationStore<T> implements IConfigurationStore<T> {
     return this.servingStore.isInitialized() && (this.persistentStore?.isInitialized() ?? true);
   }
 
-  public get(key: string): T {
+  public get(key: string): T | null {
     if (!this.servingStore.isInitialized()) {
       logger.warn('getting a value from a ServingStore that is not initialized.');
     }
@@ -51,7 +51,7 @@ export class HybridConfigurationStore<T> implements IConfigurationStore<T> {
     return this.servingStore.getKeys();
   }
 
-  public async setEntries(entries: Record<string, any>): Promise<void> {
+  public async setEntries(entries: Record<string, T>): Promise<void> {
     if (this.persistentStore) {
       // Persistence store is now initialized and should mark itself accordingly.
       await this.persistentStore.setEntries(entries);

--- a/src/configuration-store/hybrid.store.ts
+++ b/src/configuration-store/hybrid.store.ts
@@ -1,0 +1,59 @@
+import { logger } from '../application-logger';
+
+import { IAsyncStore, IConfigurationStore, ISyncStore } from './configuration-store';
+
+export class HybridConfigurationStore<T> implements IConfigurationStore<T> {
+  servingStore: ISyncStore<T>;
+  persistentStore: IAsyncStore<T> | null;
+
+  constructor(servingStore: ISyncStore<T>, persistentStore: IAsyncStore<T> | null) {
+    this.servingStore = servingStore;
+    this.persistentStore = persistentStore;
+  }
+
+  /**
+   * Initialize the configuration store by loading the entries from the persistent store into the serving store.
+   */
+  async init(): Promise<void> {
+    if (this.persistentStore) {
+      if (!this.persistentStore.isInitialized()) {
+        /**
+         * The initial remote request to the remote API failed
+         * or never happened because we are in the cool down period.
+         *
+         * Shows a log message that the assignments served from the serving store
+         * may be stale.
+         */
+        logger.warn(
+          'Persistent store is not initialized from remote configuration. Serving assignments that may be stale.',
+        );
+      }
+
+      const entries = await this.persistentStore.getEntries();
+      this.servingStore.setEntries(entries);
+    }
+  }
+
+  public isInitialized(): boolean {
+    return this.servingStore.isInitialized() && (this.persistentStore?.isInitialized() ?? true);
+  }
+
+  public get(key: string): T {
+    if (!this.servingStore.isInitialized()) {
+      logger.warn('getting a value from a ServingStore that is not initialized.');
+    }
+    return this.servingStore.get(key);
+  }
+
+  public getKeys(): string[] {
+    return this.servingStore.getKeys();
+  }
+
+  public async setEntries(entries: Record<string, any>): Promise<void> {
+    if (this.persistentStore) {
+      // Persistence store is now initialized and should mark itself accordingly.
+      await this.persistentStore.setEntries(entries);
+    }
+    this.servingStore.setEntries(entries);
+  }
+}

--- a/src/configuration-store/hybrid.store.ts
+++ b/src/configuration-store/hybrid.store.ts
@@ -15,23 +15,25 @@ export class HybridConfigurationStore<T> implements IConfigurationStore<T> {
    * Initialize the configuration store by loading the entries from the persistent store into the serving store.
    */
   async init(): Promise<void> {
-    if (this.persistentStore) {
-      if (!this.persistentStore.isInitialized()) {
-        /**
-         * The initial remote request to the remote API failed
-         * or never happened because we are in the cool down period.
-         *
-         * Shows a log message that the assignments served from the serving store
-         * may be stale.
-         */
-        logger.warn(
-          'Persistent store is not initialized from remote configuration. Serving assignments that may be stale.',
-        );
-      }
-
-      const entries = await this.persistentStore.getEntries();
-      this.servingStore.setEntries(entries);
+    if (!this.persistentStore) {
+      return;
     }
+
+    if (!this.persistentStore.isInitialized()) {
+      /**
+       * The initial remote request to the remote API failed
+       * or never happened because we are in the cool down period.
+       *
+       * Shows a log message that the assignments served from the serving store
+       * may be stale.
+       */
+      logger.warn(
+        'Persistent store is not initialized from remote configuration. Serving assignments that may be stale.',
+      );
+    }
+
+    const entries = await this.persistentStore.getEntries();
+    this.servingStore.setEntries(entries);
   }
 
   public isInitialized(): boolean {

--- a/src/configuration-store/memory.store.spec.ts
+++ b/src/configuration-store/memory.store.spec.ts
@@ -1,0 +1,40 @@
+import { MemoryOnlyConfigurationStore } from './memory.store';
+
+describe('MemoryOnlyConfigurationStore', () => {
+  let memoryStore: MemoryOnlyConfigurationStore<string>;
+
+  beforeEach(() => {
+    memoryStore = new MemoryOnlyConfigurationStore();
+  });
+
+  it('should initialize without any entries', () => {
+    expect(memoryStore.isInitialized()).toBe(false);
+    expect(memoryStore.getKeys()).toEqual([]);
+  });
+
+  it('should return null for non-existent keys', () => {
+    expect(memoryStore.get('nonexistent')).toBeNull();
+  });
+
+  it('should allow setting and retrieving entries', async () => {
+    await memoryStore.setEntries({ key1: 'value1', key2: 'value2' });
+    expect(memoryStore.get('key1')).toBe('value1');
+    expect(memoryStore.get('key2')).toBe('value2');
+  });
+
+  it('should report initialized after setting entries', async () => {
+    await memoryStore.setEntries({ key1: 'value1' });
+    expect(memoryStore.isInitialized()).toBe(true);
+  });
+
+  it('should return all keys', async () => {
+    await memoryStore.setEntries({ key1: 'value1', key2: 'value2', key3: 'value3' });
+    expect(memoryStore.getKeys()).toEqual(['key1', 'key2', 'key3']);
+  });
+
+  it('should overwrite existing entries', async () => {
+    await memoryStore.setEntries({ key1: 'value1' });
+    await memoryStore.setEntries({ key1: 'newValue1' });
+    expect(memoryStore.get('key1')).toBe('newValue1');
+  });
+});

--- a/src/configuration-store/memory.store.ts
+++ b/src/configuration-store/memory.store.ts
@@ -1,0 +1,60 @@
+import { IAsyncStore, IConfigurationStore, ISyncStore } from './configuration-store';
+
+export class MemoryStore<T> implements ISyncStore<T> {
+  private store: Record<string, string> = {};
+  private initialized = false;
+
+  get<T>(key: string): T {
+    const rval = this.store[key];
+    return rval ? JSON.parse(rval) : null;
+  }
+
+  getKeys(): string[] {
+    return Object.keys(this.store);
+  }
+
+  isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  setEntries<T>(entries: Record<string, T>): void {
+    Object.entries(entries).forEach(([key, val]) => {
+      this.store[key] = JSON.stringify(val);
+    });
+    this.initialized = true;
+  }
+}
+
+export class MemoryOnlyConfigurationStore<T> implements IConfigurationStore<T> {
+  servingStore: ISyncStore<T>;
+  persistentStore: IAsyncStore<T> | null;
+  private initialized: boolean;
+
+  constructor() {
+    this.servingStore = new MemoryStore<T>();
+    this.persistentStore = null;
+    this.initialized = false;
+  }
+
+  init(): Promise<void> {
+    this.initialized = true;
+    return Promise.resolve();
+  }
+
+  get(key: string): T {
+    return this.servingStore.get(key);
+  }
+
+  getKeys(): string[] {
+    return this.servingStore.getKeys();
+  }
+
+  isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  async setEntries(entries: Record<string, T>): Promise<void> {
+    this.servingStore.setEntries(entries);
+    this.initialized = true;
+  }
+}

--- a/src/configuration-store/memory.store.ts
+++ b/src/configuration-store/memory.store.ts
@@ -1,12 +1,11 @@
 import { IAsyncStore, IConfigurationStore, ISyncStore } from './configuration-store';
 
 export class MemoryStore<T> implements ISyncStore<T> {
-  private store: Record<string, string> = {};
+  private store: Record<string, T> = {};
   private initialized = false;
 
-  get<T>(key: string): T {
-    const rval = this.store[key];
-    return rval ? JSON.parse(rval) : null;
+  get(key: string): T | null {
+    return this.store[key] ?? null;
   }
 
   getKeys(): string[] {
@@ -17,9 +16,9 @@ export class MemoryStore<T> implements ISyncStore<T> {
     return this.initialized;
   }
 
-  setEntries<T>(entries: Record<string, T>): void {
+  setEntries(entries: Record<string, T>): void {
     Object.entries(entries).forEach(([key, val]) => {
-      this.store[key] = JSON.stringify(val);
+      this.store[key] = val;
     });
     this.initialized = true;
   }
@@ -41,7 +40,7 @@ export class MemoryOnlyConfigurationStore<T> implements IConfigurationStore<T> {
     return Promise.resolve();
   }
 
-  get(key: string): T {
+  get(key: string): T | null {
     return this.servingStore.get(key);
   }
 

--- a/src/flag-configuration-requestor.ts
+++ b/src/flag-configuration-requestor.ts
@@ -1,4 +1,4 @@
-import { IConfigurationStore } from './configuration-store';
+import { IConfigurationStore } from './configuration-store/configuration-store';
 import { IHttpClient } from './http-client';
 import { Flag } from './interfaces';
 
@@ -9,14 +9,17 @@ interface IUniversalFlagConfig {
 }
 
 export default class FlagConfigurationRequestor {
-  constructor(private configurationStore: IConfigurationStore, private httpClient: IHttpClient) {}
+  constructor(
+    private configurationStore: IConfigurationStore<Flag>,
+    private httpClient: IHttpClient,
+  ) {}
 
   async fetchAndStoreConfigurations(): Promise<Record<string, Flag>> {
     const responseData = await this.httpClient.get<IUniversalFlagConfig>(UFC_ENDPOINT);
     if (!responseData) {
       return {};
     }
-    this.configurationStore.setEntries<Flag>(responseData.flags);
+    await this.configurationStore.setEntries(responseData.flags);
     return responseData.flags;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@ import { AssignmentCache } from './assignment-cache';
 import { IAssignmentHooks } from './assignment-hooks';
 import { IAssignmentLogger, IAssignmentEvent } from './assignment-logger';
 import EppoClient, { FlagConfigurationRequestParameters, IEppoClient } from './client/eppo-client';
-import { IConfigurationStore } from './configuration-store';
+import { IConfigurationStore } from './configuration-store/configuration-store';
+import { HybridConfigurationStore } from './configuration-store/hybrid.store';
 import * as constants from './constants';
 import FlagConfigRequestor from './flag-configuration-requestor';
 import HttpClient from './http-client';
@@ -21,6 +22,7 @@ export {
   HttpClient,
   validation,
   IConfigurationStore,
+  HybridConfigurationStore,
   AssignmentCache,
   FlagConfigurationRequestParameters,
   Flag,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1436,11 +1436,6 @@ colorette@^2.0.14:
   resolved "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
-colorette@^2.0.7:
-  version "2.0.20"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
-  integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
-
 combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz"
@@ -1525,11 +1520,6 @@ data-urls@^3.0.2:
     abab "^2.0.6"
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
-
-dateformat@^4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
-  integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
 debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
@@ -1642,13 +1632,6 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
-end-of-stream@^1.1.0:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
-  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
-  dependencies:
-    once "^1.4.0"
 
 enhanced-resolve@^5.0.0, enhanced-resolve@^5.10.0:
   version "5.15.0"
@@ -1978,11 +1961,6 @@ expect@^29.0.0, expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
-fast-copy@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.2.tgz#59c68f59ccbcac82050ba992e0d5c389097c9d35"
-  integrity sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==
-
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
@@ -2018,11 +1996,6 @@ fast-redact@^3.1.1:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.5.0.tgz#e9ea02f7e57d0cd8438180083e93077e496285e4"
   integrity sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==
-
-fast-safe-stringify@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
-  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
 fastest-levenshtein@^1.0.12:
   version "1.0.14"
@@ -2271,11 +2244,6 @@ hasown@^2.0.0:
   integrity sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
   dependencies:
     function-bind "^1.1.2"
-
-help-me@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/help-me/-/help-me-5.0.0.tgz#b1ebe63b967b74060027c2ac61f9be12d354a6f6"
-  integrity sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==
 
 html-encoding-sniffer@^3.0.0:
   version "3.0.0"
@@ -2966,11 +2934,6 @@ jest@^29.7.0:
     import-local "^3.0.2"
     jest-cli "^29.7.0"
 
-joycon@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
-  integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
-
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
@@ -3296,7 +3259,7 @@ on-exit-leak-free@^2.1.0:
   resolved "https://registry.yarnpkg.com/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz#fed195c9ebddb7d9e4c3842f93f281ac8dadd3b8"
   integrity sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==
 
-once@^1.3.0, once@^1.3.1, once@^1.4.0:
+once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -3443,14 +3406,6 @@ picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-pino-abstract-transport@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz#97f9f2631931e242da531b5c66d3079c12c9d1b5"
-  integrity sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==
-  dependencies:
-    readable-stream "^4.0.0"
-    split2 "^4.0.0"
-
 pino-abstract-transport@v1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz#083d98f966262164504afb989bccd05f665937a8"
@@ -3458,26 +3413,6 @@ pino-abstract-transport@v1.1.0:
   dependencies:
     readable-stream "^4.0.0"
     split2 "^4.0.0"
-
-pino-pretty@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-11.0.0.tgz#9b883f7b933f58fa94caa44225aab302409461ef"
-  integrity sha512-YFJZqw59mHIY72wBnBs7XhLGG6qpJMa4pEQTRgEPEbjIYbng2LXEZZF1DoyDg9CfejEy8uZCyzpcBXXG0oOCwQ==
-  dependencies:
-    colorette "^2.0.7"
-    dateformat "^4.6.3"
-    fast-copy "^3.0.0"
-    fast-safe-stringify "^2.1.1"
-    help-me "^5.0.0"
-    joycon "^3.1.1"
-    minimist "^1.2.6"
-    on-exit-leak-free "^2.1.0"
-    pino-abstract-transport "^1.0.0"
-    pump "^3.0.0"
-    readable-stream "^4.0.0"
-    secure-json-parse "^2.4.0"
-    sonic-boom "^3.0.0"
-    strip-json-comments "^3.1.1"
 
 pino-std-serializers@^6.0.0:
   version "6.2.2"
@@ -3566,14 +3501,6 @@ psl@^1.1.33:
   version "1.8.0"
   resolved "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
-
-pump@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
-  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
 
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
@@ -3753,11 +3680,6 @@ schema-utils@^3.1.0, schema-utils@^3.1.1:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
-secure-json-parse@^2.4.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.7.0.tgz#5a5f9cd6ae47df23dba3151edd06855d47e09862"
-  integrity sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==
-
 semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
@@ -3819,13 +3741,6 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
-
-sonic-boom@^3.0.0:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-3.8.1.tgz#d5ba8c4e26d6176c9a1d14d549d9ff579a163422"
-  integrity sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==
-  dependencies:
-    atomic-sleep "^1.0.0"
 
 sonic-boom@^3.7.0:
   version "3.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1436,6 +1436,11 @@ colorette@^2.0.14:
   resolved "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
+colorette@^2.0.7:
+  version "2.0.20"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
+  integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
+
 combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz"
@@ -1520,6 +1525,11 @@ data-urls@^3.0.2:
     abab "^2.0.6"
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
+
+dateformat@^4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
+  integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
 debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
@@ -1632,6 +1642,13 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+end-of-stream@^1.1.0:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+  dependencies:
+    once "^1.4.0"
 
 enhanced-resolve@^5.0.0, enhanced-resolve@^5.10.0:
   version "5.15.0"
@@ -1961,6 +1978,11 @@ expect@^29.0.0, expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
+fast-copy@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.2.tgz#59c68f59ccbcac82050ba992e0d5c389097c9d35"
+  integrity sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
@@ -1996,6 +2018,11 @@ fast-redact@^3.1.1:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.5.0.tgz#e9ea02f7e57d0cd8438180083e93077e496285e4"
   integrity sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==
+
+fast-safe-stringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
+  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
 fastest-levenshtein@^1.0.12:
   version "1.0.14"
@@ -2244,6 +2271,11 @@ hasown@^2.0.0:
   integrity sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
   dependencies:
     function-bind "^1.1.2"
+
+help-me@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/help-me/-/help-me-5.0.0.tgz#b1ebe63b967b74060027c2ac61f9be12d354a6f6"
+  integrity sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==
 
 html-encoding-sniffer@^3.0.0:
   version "3.0.0"
@@ -2934,6 +2966,11 @@ jest@^29.7.0:
     import-local "^3.0.2"
     jest-cli "^29.7.0"
 
+joycon@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
+  integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
@@ -3259,7 +3296,7 @@ on-exit-leak-free@^2.1.0:
   resolved "https://registry.yarnpkg.com/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz#fed195c9ebddb7d9e4c3842f93f281ac8dadd3b8"
   integrity sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==
 
-once@^1.3.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -3406,6 +3443,14 @@ picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+pino-abstract-transport@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz#97f9f2631931e242da531b5c66d3079c12c9d1b5"
+  integrity sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==
+  dependencies:
+    readable-stream "^4.0.0"
+    split2 "^4.0.0"
+
 pino-abstract-transport@v1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz#083d98f966262164504afb989bccd05f665937a8"
@@ -3413,6 +3458,26 @@ pino-abstract-transport@v1.1.0:
   dependencies:
     readable-stream "^4.0.0"
     split2 "^4.0.0"
+
+pino-pretty@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-11.0.0.tgz#9b883f7b933f58fa94caa44225aab302409461ef"
+  integrity sha512-YFJZqw59mHIY72wBnBs7XhLGG6qpJMa4pEQTRgEPEbjIYbng2LXEZZF1DoyDg9CfejEy8uZCyzpcBXXG0oOCwQ==
+  dependencies:
+    colorette "^2.0.7"
+    dateformat "^4.6.3"
+    fast-copy "^3.0.0"
+    fast-safe-stringify "^2.1.1"
+    help-me "^5.0.0"
+    joycon "^3.1.1"
+    minimist "^1.2.6"
+    on-exit-leak-free "^2.1.0"
+    pino-abstract-transport "^1.0.0"
+    pump "^3.0.0"
+    readable-stream "^4.0.0"
+    secure-json-parse "^2.4.0"
+    sonic-boom "^3.0.0"
+    strip-json-comments "^3.1.1"
 
 pino-std-serializers@^6.0.0:
   version "6.2.2"
@@ -3501,6 +3566,14 @@ psl@^1.1.33:
   version "1.8.0"
   resolved "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
+
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
 
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
@@ -3680,6 +3753,11 @@ schema-utils@^3.1.0, schema-utils@^3.1.1:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
+secure-json-parse@^2.4.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.7.0.tgz#5a5f9cd6ae47df23dba3151edd06855d47e09862"
+  integrity sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==
+
 semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
@@ -3741,6 +3819,13 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+sonic-boom@^3.0.0:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-3.8.1.tgz#d5ba8c4e26d6176c9a1d14d549d9ff579a163422"
+  integrity sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==
+  dependencies:
+    atomic-sleep "^1.0.0"
 
 sonic-boom@^3.7.0:
   version "3.8.0"


### PR DESCRIPTION
## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Support the migration to alternative upstream storages, such as `chrome.storage.local` or `IndexedDb` by introducing a change to the `setEntries` method of the configuration to allow async writes.

Our goal for now is to maintain the public APIs (`get*Assignment`) as synchronous and this requires keeping the accessor methods sync. This is accomplished by keeping an in-memory sync cache of the configuration.

It is up to upstream libraries to implement against this interface - the shape will look like:

**javascript client - example** 

If the init code detects that `chrome.storage.local` is available (such as in the chromium browsers):

```
class ChromeStorageConfigurationStore {
  syncStore: Record<string, T>
  asyncStore: chrome.storage.local

  get() -> fetch from syncStore
  
  setEntries(entries): Promise<void>
    syncStore = entries // over-write all entries with updated copy
    await asyncStore.overwriteAll(entries) // over-write all entries with updated copy
    return Promise.resolve()
}
```

Otherwise if `localStorage` is available:

```
class LocalStorageConfigurationStore {
  syncStore: localStorage

  get() -> fetch from syncStore
  
  setEntries(entries): Promise<void>
    syncStore = entries // over-write all entries with updated copy
    return Promise.resolve()
}
```

finally if `localStorage` is not available at all; we can still hold configuration in memory

```
class MemoryConfigurationStore {
  syncStore: Record<string, T>

  get() -> fetch from syncStore
  
  setEntries(entries): Promise<void>
    syncStore = entries // over-write all entries with updated copy
    return Promise.resolve()
}
```

👉 another important implementation upstream libraries will need to make is making sure that when configuration is loaded from the remote API, to clear out all keys. the use case here is making sure that keys from disabled or deleted flags are no longer present locally.

👉 WIP implementation https://github.com/Eppo-exp/js-client-sdk/pull/59

## Description
[//]: # (Describe your changes in detail)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

New unit tests.

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)

## Reviewers

1. Please take a careful look at the behavior codified in `HybridConfigurationStore` as it will be applied against the upstream repositories.
2. 🤔 The RAC API is defined by `Record<string, Flag>` but there is also handling for obfuscated flags. I believe it makes sense to store the flags in obfuscated format on disk. Do you think the current implementation handles the behavior in a desirable fashion?