### PR TITLE
Add configuration skipInitialPoll to allow the SDK to be configured without any CDN requests. (FF-2047)

### DIFF
--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -108,6 +108,7 @@ export type FlagConfigurationRequestParameters = {
   pollAfterSuccessfulInitialization?: boolean;
   pollAfterFailedInitialization?: boolean;
   throwOnFailedInitialization?: boolean;
+  skipInitialPoll?: boolean;
 };
 
 export default class EppoClient implements IEppoClient {
@@ -181,6 +182,7 @@ export default class EppoClient implements IEppoClient {
           this.configurationRequestParameters.pollAfterFailedInitialization ?? false,
         errorOnFailedStart:
           this.configurationRequestParameters.throwOnFailedInitialization ?? false,
+        skipInitialPoll: this.configurationRequestParameters.skipInitialPoll ?? false,
       },
     );
 

--- a/src/poller.spec.ts
+++ b/src/poller.spec.ts
@@ -22,6 +22,12 @@ describe('poller', () => {
   });
 
   describe('initial startup', () => {
+    it('skips initial poll if configured to do so', async () => {
+      const poller = initPoller(testIntervalMs, noOpCallback, { skipInitialPoll: true });
+      await poller.start();
+      td.verify(noOpCallback(), { times: 0 });
+    });
+
     it('retries startup poll within same promise', async () => {
       const pollerRetries = 3;
       let callCount = 0;

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -23,6 +23,7 @@ export default function initPoller(
     pollAfterSuccessfulStart?: boolean;
     errorOnFailedStart?: boolean;
     pollAfterFailedStart?: boolean;
+    skipInitialPoll?: boolean;
   },
 ): IPoller {
   let stopped = false;
@@ -34,8 +35,9 @@ export default function initPoller(
   const start = async () => {
     stopped = false;
     let startRequestSuccess = false;
-    let startAttemptsRemaining =
-      1 + (options?.maxStartRetries ?? DEFAULT_INITIAL_CONFIG_REQUEST_RETRIES);
+    let startAttemptsRemaining = options?.skipInitialPoll
+      ? 0
+      : 1 + (options?.maxStartRetries ?? DEFAULT_INITIAL_CONFIG_REQUEST_RETRIES);
 
     let startErrorToThrow = null;
 


### PR DESCRIPTION
…ithout any CDN requests. (FF-2047)

---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Users of the JS client SDK (browser) have a desire for an off-line mode that can be paired with providing a custom persistence store implementation that which can be bootstrapped by a server process and reduce client-sourced CDN requests to 0. The serving cache will be populated from this persistent store on startup.

JS clients have polling disabled by default but an initial request is still made.

## Description
[//]: # (Describe your changes in detail)

Adds a new configuration parameter `skipInitialPoll` and implements it in the poller. This paired with previously added support for a custom persistence store allows for an off-line mode that is populated off-process.

![feature store-Page-2 drawio](https://github.com/Eppo-exp/js-client-sdk-common/assets/57361/57d83f7a-b527-479b-93e3-559b50094357)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

New unit test.

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
