### PR TITLE
Add support for isExpired in configuration store to gate CDN requests…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -639,6 +639,24 @@ describe('EppoClient E2E test', () => {
       expect(variation).toBe(pi);
     });
 
+    it('Does not fetch configurations if the configuration store is unexpired', async () => {
+      class MockStore extends MemoryOnlyConfigurationStore<Flag | ObfuscatedFlag> {
+        async isExpired(): Promise<boolean> {
+          return false;
+        }
+      }
+
+      client = new EppoClient(new MockStore(), requestConfiguration);
+      client.setIsGracefulFailureMode(false);
+      // no configuration loaded
+      let variation = client.getNumericAssignment(flagKey, subject, {}, 0.0);
+      expect(variation).toBe(0.0);
+      // have client fetch configurations
+      await client.fetchFlagConfigurations();
+      variation = client.getNumericAssignment(flagKey, subject, {}, 0.0);
+      expect(variation).toBe(0.0);
+    });
+
     it.each([
       { pollAfterSuccessfulInitialization: false },
       { pollAfterSuccessfulInitialization: true },

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -150,6 +150,11 @@ export default class EppoClient implements IEppoClient {
       this.requestPoller.stop();
     }
 
+    const isExpired = await this.configurationStore.isExpired();
+    if (!isExpired) {
+      return;
+    }
+
     // todo: consider injecting the IHttpClient interface
     const httpClient = new FetchHttpClient(
       this.configurationRequestParameters.baseUrl || DEFAULT_BASE_URL,

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -154,6 +154,9 @@ export default class EppoClient implements IEppoClient {
 
     const isExpired = await this.configurationStore.isExpired();
     if (!isExpired) {
+      logger.info(
+        '[Eppo SDK] Configuration store is not expired. Skipping fetching flag configurations',
+      );
       return;
     }
 

--- a/src/configuration-store/configuration-store.ts
+++ b/src/configuration-store/configuration-store.ts
@@ -28,6 +28,7 @@ export interface IConfigurationStore<T> {
   get(key: string): T | null;
   getKeys(): string[];
   isInitialized(): boolean;
+  isExpired(): Promise<boolean>;
   setEntries(entries: Record<string, T>): Promise<void>;
 }
 
@@ -40,6 +41,7 @@ export interface ISyncStore<T> {
 
 export interface IAsyncStore<T> {
   isInitialized(): boolean;
+  isExpired(): Promise<boolean>;
   getEntries(): Promise<Record<string, T>>;
   setEntries(entries: Record<string, T>): Promise<void>;
 }

--- a/src/configuration-store/hybrid.store.spec.ts
+++ b/src/configuration-store/hybrid.store.spec.ts
@@ -17,6 +17,7 @@ describe('HybridConfigurationStore', () => {
     asyncStoreMock = {
       getEntries: jest.fn(),
       isInitialized: jest.fn(),
+      isExpired: jest.fn(),
       setEntries: jest.fn(),
     };
 
@@ -32,6 +33,21 @@ describe('HybridConfigurationStore', () => {
       await store.init();
 
       expect(syncStoreMock.setEntries).toHaveBeenCalledWith(entries);
+    });
+  });
+
+  describe('isExpired', () => {
+    it("is the persistent store's expired value", async () => {
+      (asyncStoreMock.isExpired as jest.Mock).mockResolvedValue(true);
+      expect(await store.isExpired()).toBe(true);
+
+      (asyncStoreMock.isExpired as jest.Mock).mockResolvedValue(false);
+      expect(await store.isExpired()).toBe(false);
+    });
+
+    it('is true without a persistent store', async () => {
+      const mixedStoreWithNull = new HybridConfigurationStore(syncStoreMock, null);
+      expect(await mixedStoreWithNull.isExpired()).toBe(true);
     });
   });
 

--- a/src/configuration-store/hybrid.store.ts
+++ b/src/configuration-store/hybrid.store.ts
@@ -40,6 +40,11 @@ export class HybridConfigurationStore<T> implements IConfigurationStore<T> {
     return this.servingStore.isInitialized() && (this.persistentStore?.isInitialized() ?? true);
   }
 
+  public async isExpired(): Promise<boolean> {
+    const isExpired = (await this.persistentStore?.isExpired()) ?? true;
+    return isExpired;
+  }
+
   public get(key: string): T | null {
     if (!this.servingStore.isInitialized()) {
       logger.warn(`${loggerPrefix} getting a value from a ServingStore that is not initialized.`);

--- a/src/configuration-store/memory.store.spec.ts
+++ b/src/configuration-store/memory.store.spec.ts
@@ -12,6 +12,10 @@ describe('MemoryOnlyConfigurationStore', () => {
     expect(memoryStore.getKeys()).toEqual([]);
   });
 
+  it('is always expired', async () => {
+    expect(await memoryStore.isExpired()).toBe(true);
+  });
+
   it('should return null for non-existent keys', () => {
     expect(memoryStore.get('nonexistent')).toBeNull();
   });

--- a/src/configuration-store/memory.store.ts
+++ b/src/configuration-store/memory.store.ts
@@ -48,6 +48,10 @@ export class MemoryOnlyConfigurationStore<T> implements IConfigurationStore<T> {
     return this.servingStore.getKeys();
   }
 
+  async isExpired(): Promise<boolean> {
+    return true;
+  }
+
   isInitialized(): boolean {
     return this.initialized;
   }


### PR DESCRIPTION
… (FF-2048)

---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Customers with very short sessions (for example, chrome extensions) experience many more CDN requests than those with longer sessions. It is their interest to have more control over the rate of refreshes and balance that against being tolerant against stale flags.

For example, an owner of a chrome extension may know that during the lifetime of a financial transaction on a website where the extension is used repeatedly, a cool down period of 2 minutes will allow for a CDN request on the first open of the chrome extension to get the latest flags, while pausing CDN requests for subsequent requests in that period whenever the extension is re-opened.

We will provide an `isExpired` API to the `ConfigurationStore` and only perform CDN requests when the store declares itself as expired.

The default case will likely be that `isExpired` returns `true` always and the SDK behavior will be unchanged.

Upstream clients will implement `isExpired` using the available APIs on their platforms and the desired policies. Paired with these changes will be support for a `cooldown` period which will be a user provided SDK init parameter that governs how often a client should be stale, even when the poller executes its callback. 

**chrome extension**

```
class ChromeStorage {

  constructor(private cooldownSeconds: number) {}

  setEntries(..) {
  
     await chrome.storage.local.set('lastUpdated', new Date())
  }

  isExpired():Promise<boolean> {
    await lastUpdated = chrome.storage.local.get('lastUpdated')

    const currentTime = new Date();
    const timeSinceLastUpdate = currentTime.getTime() - lastUpdated.getTime();
    const cooldownMilliseconds = cooldownPeriodSeconds * 1000; // Convert cooldown to milliseconds

    return timeSinceLastUpdate >= cooldownMilliseconds;
  }

}
```

The other classes will implement the functions in similar ways, or choose to return whatever else is appropriate.

## Description
[//]: # (Describe your changes in detail)

Upstream clients will implement `isExpired` using the available APIs on their platforms.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

New unit tests

## Questions for reviewers

1. There are several ways to "block" CDN requests and all of them have trade-offs

Ultimately the "cooldown period" upstream clients will implement is not exact.

This approach continues running the poller and it acts as the clock - cool down periods significantly shorter than the period of the poller don't make much sense. However they will still be useful for stopping the initial request from happening during repeated short sessions - such as with the use case of the chrome extension.

2. No new SDK parameters are added to commons 

The cooldown period will be implemented in the JS SDK for the configuration stores that need it.

3. Does the word `isExpired` convey the correct meaning? 

It's important to get it right so users who implement their own persistent store have an understanding of its role in the SDK's operation.

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
