### PR TITLE
[UFC] Use regex full match

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/rules.spec.ts
+++ b/src/rules.spec.ts
@@ -14,6 +14,109 @@ describe('rules', () => {
     });
   });
 
+  describe('matchesRule | regex special cases', () => {
+    it('correctly matches on full email regex', () => {
+      const emailMatchesCondition: Rule = {
+        conditions: [
+          {
+            operator: OperatorType.MATCHES,
+            attribute: 'email',
+            value: '.*@example\\.com',
+          },
+        ],
+      };
+      expect(matchesRule(emailMatchesCondition, { email: 'user@example.com' }, false)).toBe(true);
+      expect(matchesRule(emailMatchesCondition, { email: 'user@test.com' }, false)).toBe(false);
+    });
+
+    it('correctly handles regex that has anchors', () => {
+      const emailMatchesConditionWithAnchors: Rule = {
+        conditions: [
+          {
+            operator: OperatorType.MATCHES,
+            attribute: 'email',
+            value: '^.*@example\\.com$',
+          },
+        ],
+      };
+
+      expect(
+        matchesRule(emailMatchesConditionWithAnchors, { email: 'user@example.com' }, false),
+      ).toBe(true);
+      expect(matchesRule(emailMatchesConditionWithAnchors, { email: 'user@test.com' }, false)).toBe(
+        false,
+      );
+    });
+    it('correctly does not match on partial email regex', () => {
+      const partialEmailMatchesCondition: Rule = {
+        conditions: [
+          {
+            operator: OperatorType.MATCHES,
+            attribute: 'email',
+            value: '@example\\.com',
+          },
+        ],
+      };
+      expect(matchesRule(partialEmailMatchesCondition, { email: 'user@example.com' }, false)).toBe(
+        false,
+      );
+    });
+
+    it('correctly does not match on full email regex', () => {
+      const emailNotMatchesCondition: Rule = {
+        conditions: [
+          {
+            operator: OperatorType.NOT_MATCHES,
+            attribute: 'email',
+            value: '.*@example\\.com',
+          },
+        ],
+      };
+      expect(matchesRule(emailNotMatchesCondition, { email: 'user@example.com' }, false)).toBe(
+        false,
+      );
+      expect(matchesRule(emailNotMatchesCondition, { email: 'user@test.com' }, false)).toBe(true);
+    });
+
+    it('correctly does not match on full email regex with anchors', () => {
+      const emailNotMatchesConditionWithAnchors: Rule = {
+        conditions: [
+          {
+            operator: OperatorType.NOT_MATCHES,
+            attribute: 'email',
+            value: '^.*@example\\.com$',
+          },
+        ],
+      };
+      expect(
+        matchesRule(emailNotMatchesConditionWithAnchors, { email: 'user@example.com' }, false),
+      ).toBe(false);
+      expect(
+        matchesRule(emailNotMatchesConditionWithAnchors, { email: 'user@test.com' }, false),
+      ).toBe(true);
+    });
+
+    it('corredly does not match on partial email regex', () => {
+      const partialNotEmailMatchesCondition: Rule = {
+        conditions: [
+          {
+            operator: OperatorType.NOT_MATCHES,
+            attribute: 'email',
+            value: '@example\\.com',
+          },
+        ],
+      };
+      expect(
+        matchesRule(partialNotEmailMatchesCondition, { email: 'user@example.com' }, false),
+      ).toBe(true);
+      expect(matchesRule(partialNotEmailMatchesCondition, { email: '@example.com' }, false)).toBe(
+        false,
+      );
+      expect(matchesRule(partialNotEmailMatchesCondition, { email: 'user@test.com' }, false)).toBe(
+        true,
+      );
+    });
+  });
   describe('matchesRule | standard rules', () => {
     const ruleWithEmptyConditions: Rule = {
       conditions: [],
@@ -104,6 +207,7 @@ describe('rules', () => {
         },
       ],
     };
+
     const subjectAttributes = {
       totalSales: 50,
       version: '1.15.0',

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -186,7 +186,9 @@ function evaluateCondition(subjectAttributes: Record<string, any>, condition: Co
         }
         return compareNumber(value, condition.value, (a, b) => a < b);
       case OperatorType.MATCHES:
-        return new RegExp(condition.value as string).test(value as string);
+        return new RegExp(`^${condition.value as string}$`).test(value as string);
+      case OperatorType.NOT_MATCHES:
+        return !new RegExp(`^${condition.value as string}$`).test(value as string);
       case OperatorType.ONE_OF:
         return isOneOf(value.toString(), condition.value);
       case OperatorType.NOT_ONE_OF:
@@ -249,9 +251,9 @@ function evaluateObfuscatedCondition(
           (a, b) => a < b,
         );
       case ObfuscatedOperatorType.MATCHES:
-        return new RegExp(decodeBase64(condition.value as string)).test(value as string);
+        return new RegExp(`^${decodeBase64(condition.value as string)}$`).test(value as string);
       case ObfuscatedOperatorType.NOT_MATCHES:
-        return !new RegExp(decodeBase64(condition.value as string)).test(value as string);
+        return !new RegExp(`^${decodeBase64(condition.value as string)}$`).test(value as string);
       case ObfuscatedOperatorType.ONE_OF:
         return isOneOf(getMD5Hash(value.toString()), condition.value);
       case ObfuscatedOperatorType.NOT_ONE_OF:


### PR DESCRIPTION
## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Currently the JS SDKs look for a partial regex rather than a full regex match

## Description
[//]: # (Describe your changes in detail)

Add anchors to the regex expression to force a full match. Note that double anchors does not matter.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

Added additional tests

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
