### PR TITLE
[UFC] add missing not_matches operator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/rules.spec.ts
+++ b/src/rules.spec.ts
@@ -203,8 +203,16 @@ describe('rules', () => {
       expect(matchesRule(ruleWithMatchesCondition, failingAttributes, false)).toBe(false);
     });
 
-    it('should return true for a rule with not_matches condition that matches the subject attributes', () => {
-      expect(matchesRule(ruleWithNotMatchesCondition, subjectAttributes, false)).toBe(false);
+    it('should return false for a rule with NOT_MATCHES condition when the subject attribute matches the condition value', () => {
+      expect(matchesRule(ruleWithNotMatchesCondition, { user_id: 'user123' }, false)).toBe(false);
+    });
+
+    it('should return true for a rule with NOT_MATCHES condition when the subject attribute does not match the condition value', () => {
+      expect(matchesRule(ruleWithNotMatchesCondition, { user_id: 'admin' }, false)).toBe(true);
+    });
+
+    it('should return true for a rule with NOT_MATCHES condition when the subject attribute does not match the condition value', () => {
+      expect(matchesRule(ruleWithNotMatchesCondition, { country: 'uk' }, false)).toBe(false);
     });
   });
 

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -187,6 +187,8 @@ function evaluateCondition(subjectAttributes: Record<string, any>, condition: Co
         return compareNumber(value, condition.value, (a, b) => a < b);
       case OperatorType.MATCHES:
         return new RegExp(condition.value as string).test(value as string);
+      case OperatorType.NOT_MATCHES:
+        return !new RegExp(condition.value as string).test(value as string);
       case OperatorType.ONE_OF:
         return isOneOf(value.toString(), condition.value);
       case OperatorType.NOT_ONE_OF:


### PR DESCRIPTION
## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

## Description
[//]: # (Describe your changes in detail)

The NOT_MATCHES operator is missing, add it

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

Added tests

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
