### PR TITLE
Add builder method to add a configuration store.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -87,6 +87,8 @@ export interface IEppoClient {
     configurationRequestParameters: FlagConfigurationRequestParameters,
   ): void;
 
+  setConfigurationStore(configurationStore: IConfigurationStore<Flag | ObfuscatedFlag>): void;
+
   fetchFlagConfigurations(): void;
 
   stopPolling(): void;
@@ -138,6 +140,10 @@ export default class EppoClient implements IEppoClient {
     configurationRequestParameters: FlagConfigurationRequestParameters,
   ) {
     this.configurationRequestParameters = configurationRequestParameters;
+  }
+
+  public setConfigurationStore(configurationStore: IConfigurationStore<Flag | ObfuscatedFlag>) {
+    this.configurationStore = configurationStore;
   }
 
   public async fetchFlagConfigurations() {


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

We need the upstream clients to be able to add the configuration store to an instantiated client inside the `init` method.

## Description
[//]: # (Describe your changes in detail)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
