### PR TITLE
Export additional assignment cache interfaces. (FF-2110)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 import { logger } from './application-logger';
-import { AssignmentCache } from './assignment-cache';
+import {
+  Cacheable,
+  AssignmentCache,
+  NonExpiringInMemoryAssignmentCache,
+  LRUInMemoryAssignmentCache,
+} from './assignment-cache';
 import { IAssignmentHooks } from './assignment-hooks';
 import { IAssignmentLogger, IAssignmentEvent } from './assignment-logger';
 import EppoClient, { FlagConfigurationRequestParameters, IEppoClient } from './client/eppo-client';
@@ -37,8 +42,13 @@ export {
   HybridConfigurationStore,
   MemoryOnlyConfigurationStore,
 
-  //
+  // Assignment cache
   AssignmentCache,
+  Cacheable,
+  NonExpiringInMemoryAssignmentCache,
+  LRUInMemoryAssignmentCache,
+
+  // Interfaces
   FlagConfigurationRequestParameters,
   Flag,
   VariationType,


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Chore: upstream libraries need access to these cache implementations, as well as the `Cacheable` interface to implement their own.

## Description
[//]: # (Describe your changes in detail)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
