### PR TITLE
Remove old MemoryStore entries when setting new entries 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ yarn-error.log
 
 test/data
 .vscode/settings.json
+.idea
 
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/configuration-store/memory.store.spec.ts
+++ b/src/configuration-store/memory.store.spec.ts
@@ -37,8 +37,14 @@ describe('MemoryOnlyConfigurationStore', () => {
   });
 
   it('should overwrite existing entries', async () => {
-    await memoryStore.setEntries({ key1: 'value1' });
-    await memoryStore.setEntries({ key1: 'newValue1' });
-    expect(memoryStore.get('key1')).toBe('newValue1');
+    await memoryStore.setEntries({ toBeReplaced: 'old value', toBeRemoved: 'delete me' });
+    expect(memoryStore.get('toBeReplaced')).toBe('old value');
+    expect(memoryStore.get('toBeRemoved')).toBe('delete me');
+    expect(memoryStore.get('toBeAdded')).toBeNull();
+
+    await memoryStore.setEntries({ toBeReplaced: 'new value', toBeAdded: 'add me' });
+    expect(memoryStore.get('toBeReplaced')).toBe('new value');
+    expect(memoryStore.get('toBeRemoved')).toBeNull();
+    expect(memoryStore.get('toBeAdded')).toBe('add me');
   });
 });

--- a/src/configuration-store/memory.store.ts
+++ b/src/configuration-store/memory.store.ts
@@ -20,6 +20,11 @@ export class MemoryStore<T> implements ISyncStore<T> {
     Object.entries(entries).forEach(([key, val]) => {
       this.store[key] = val;
     });
+    Object.keys(this.store).forEach((key) => {
+      if (typeof entries[key] === 'undefined') {
+        delete this.store[key];
+      }
+    });
     this.initialized = true;
   }
 }

--- a/src/configuration-store/memory.store.ts
+++ b/src/configuration-store/memory.store.ts
@@ -17,14 +17,7 @@ export class MemoryStore<T> implements ISyncStore<T> {
   }
 
   setEntries(entries: Record<string, T>): void {
-    Object.entries(entries).forEach(([key, val]) => {
-      this.store[key] = val;
-    });
-    Object.keys(this.store).forEach((key) => {
-      if (typeof entries[key] === 'undefined') {
-        delete this.store[key];
-      }
-    });
+    this.store = { ...entries };
     this.initialized = true;
   }
 }


### PR DESCRIPTION
_Eppo Internal:_
🎟️ **Ticket:** [FF-2268 - JS Common SDK - In Memory Store should kick out removed entries](https://linear.app/eppo/issue/FF-2268/js-common-sdk-in-memory-store-should-kick-out-removed-entries)

When updating entries in a `MemoryStore`, be sure to remove old entries.