### PR TITLE
fix(sdk): [EPD-2310] 💀 `getBoolAssignment` -> 👶 `getBooleanAssignment`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "3.0.9",
+  "version": "3.1.0",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -104,6 +104,8 @@ describe('EppoClient E2E test', () => {
 
       expect(client.getBoolAssignment(flagKey, 'subject-identifer', {}, true)).toBe(true);
       expect(client.getBoolAssignment(flagKey, 'subject-identifer', {}, false)).toBe(false);
+      expect(client.getBooleanAssignment(flagKey, 'subject-identifer', {}, true)).toBe(true);
+      expect(client.getBooleanAssignment(flagKey, 'subject-identifer', {}, false)).toBe(false);
       expect(client.getNumericAssignment(flagKey, 'subject-identifer', {}, 1)).toBe(1);
       expect(client.getNumericAssignment(flagKey, 'subject-identifer', {}, 0)).toBe(0);
       expect(client.getJSONAssignment(flagKey, 'subject-identifer', {}, {})).toEqual({});
@@ -122,6 +124,7 @@ describe('EppoClient E2E test', () => {
 
       expect(() => {
         client.getBoolAssignment(flagKey, 'subject-identifer', {}, true);
+        client.getBooleanAssignment(flagKey, 'subject-identifer', {}, true);
       }).toThrow();
 
       expect(() => {
@@ -301,6 +304,7 @@ describe('EppoClient E2E test', () => {
     const nonExistentFlag = 'non-existent-flag';
 
     expect(client.getBoolAssignment(nonExistentFlag, 'subject-identifer', {}, true)).toBe(true);
+    expect(client.getBooleanAssignment(nonExistentFlag, 'subject-identifer', {}, true)).toBe(true);
     expect(client.getNumericAssignment(nonExistentFlag, 'subject-identifer', {}, 1)).toBe(1);
     expect(client.getJSONAssignment(nonExistentFlag, 'subject-identifer', {}, {})).toEqual({});
     expect(client.getStringAssignment(nonExistentFlag, 'subject-identifer', {}, 'default')).toBe(

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -220,7 +220,7 @@ describe('EppoClient E2E test', () => {
         }[] = [];
 
         const typeAssignmentFunctions = {
-          [VariationType.BOOLEAN]: client.getBoolAssignment.bind(client),
+          [VariationType.BOOLEAN]: client.getBooleanAssignment.bind(client),
           [VariationType.NUMERIC]: client.getNumericAssignment.bind(client),
           [VariationType.INTEGER]: client.getIntegerAssignment.bind(client),
           [VariationType.STRING]: client.getStringAssignment.bind(client),
@@ -267,7 +267,7 @@ describe('EppoClient E2E test', () => {
         client.setIsGracefulFailureMode(false);
 
         const typeAssignmentFunctions = {
-          [VariationType.BOOLEAN]: client.getBoolAssignment.bind(client),
+          [VariationType.BOOLEAN]: client.getBooleanAssignment.bind(client),
           [VariationType.NUMERIC]: client.getNumericAssignment.bind(client),
           [VariationType.INTEGER]: client.getIntegerAssignment.bind(client),
           [VariationType.STRING]: client.getStringAssignment.bind(client),

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -35,11 +35,12 @@ export interface IEppoClient {
   /**
    * Maps a subject to a variation for a given experiment.
    *
-   * @param subjectKey an identifier of the experiment subject, for example a user ID.
    * @param flagKey feature flag identifier
+   * @param subjectKey an identifier of the experiment subject, for example a user ID.
    * @param subjectAttributes optional attributes associated with the subject, for example name and email.
+   * @param defaultValue default value to return if the subject is not part of the experiment sample
    * The subject attributes are used for evaluating any targeting rules tied to the experiment.
-   * @returns a variation value if the subject is part of the experiment sample, otherwise null
+   * @returns a variation value if the subject is part of the experiment sample, otherwise the default value
    * @public
    */
   getStringAssignment(
@@ -49,6 +50,9 @@ export interface IEppoClient {
     defaultValue: string,
   ): string;
 
+  /**
+   * @deprecated use getBooleanAssignment instead.
+   */
   getBoolAssignment(
     flagKey: string,
     subjectKey: string,
@@ -56,6 +60,31 @@ export interface IEppoClient {
     defaultValue: boolean,
   ): boolean;
 
+  /**
+   * Maps a subject to a boolean variation for a given experiment.
+   *
+   * @param flagKey feature flag identifier
+   * @param subjectKey an identifier of the experiment subject, for example a user ID.
+   * @param subjectAttributes optional attributes associated with the subject, for example name and email.
+   * @param defaultValue default value to return if the subject is not part of the experiment sample
+   * @returns a boolean variation value if the subject is part of the experiment sample, otherwise the default value
+   */
+  getBooleanAssignment(
+    flagKey: string,
+    subjectKey: string,
+    subjectAttributes: Record<string, AttributeType>,
+    defaultValue: boolean,
+  ): boolean;
+
+  /**
+   * Maps a subject to an Integer variation for a given experiment.
+   *
+   * @param flagKey feature flag identifier
+   * @param subjectKey an identifier of the experiment subject, for example a user ID.
+   * @param subjectAttributes optional attributes associated with the subject, for example name and email.
+   * @param defaultValue default value to return if the subject is not part of the experiment sample
+   * @returns a number variation value if the subject is part of the experiment sample, otherwise the default value
+   */
   getIntegerAssignment(
     flagKey: string,
     subjectKey: string,
@@ -63,6 +92,15 @@ export interface IEppoClient {
     defaultValue: number,
   ): number;
 
+  /**
+   * Maps a subject to a Numeric variation for a given experiment.
+   *
+   * @param flagKey feature flag identifier
+   * @param subjectKey an identifier of the experiment subject, for example a user ID.
+   * @param subjectAttributes optional attributes associated with the subject, for example name and email.
+   * @param defaultValue default value to return if the subject is not part of the experiment sample
+   * @returns a number variation value if the subject is part of the experiment sample, otherwise the default value
+   */
   getNumericAssignment(
     flagKey: string,
     subjectKey: string,
@@ -70,6 +108,15 @@ export interface IEppoClient {
     defaultValue: number,
   ): number;
 
+  /**
+   * Maps a subject to a JSON variation for a given experiment.
+   *
+   * @param flagKey feature flag identifier
+   * @param subjectKey an identifier of the experiment subject, for example a user ID.
+   * @param subjectAttributes optional attributes associated with the subject, for example name and email.
+   * @param defaultValue default value to return if the subject is not part of the experiment sample
+   * @returns a JSON object variation value if the subject is part of the experiment sample, otherwise the default value
+   */
   getJSONAssignment(
     flagKey: string,
     subjectKey: string,
@@ -228,6 +275,15 @@ export default class EppoClient implements IEppoClient {
   }
 
   public getBoolAssignment(
+    flagKey: string,
+    subjectKey: string,
+    subjectAttributes: Record<string, AttributeType>,
+    defaultValue: boolean,
+  ): boolean {
+    return this.getBooleanAssignment(flagKey, subjectKey, subjectAttributes, defaultValue);
+  }
+
+  public getBooleanAssignment(
     flagKey: string,
     subjectKey: string,
     subjectAttributes: Record<string, AttributeType>,


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: [EPD-2310](https://linear.app/eppo/issue/EPD-2310/[sdk]-deprecate-getboolassignment-and-create-getbooleanassignment)

## Motivation and Context
The [README](https://github.com/Eppo-exp/js-client-sdk/blob/main/README.md#assign-anywhere) refers to a `getBooleanAssignment` method that doesnt exist.
From Slack discussion:
```
Sven
  1 hour ago
Yes I think the JS clients are odd in that they use getBoolAssignment (even though the type is boolean :confused_dog: ) — feel free to update the docs to fix it! :slightly_smiling_face:


felipecsl
  [1 hour ago](https://eppo-group.slack.com/archives/C0541NTN6QH/p1717539948841059?thread_ts=1717539554.110119&cid=C0541NTN6QH)
will do!

Aaron
  21 minutes ago
OR... hear me out... make the correctly named assignment and throw on a @deprecated to that one :sweat_smile:
```

According to Semver, this will require a minor version bump since this is a backwards compatible change.

## Description
* Deprecate `getBoolAssignment`
* Redirect `getBoolAssignment` to `getBooleanAssignment`
* Add some JSDocs because why not

## How has this been tested?
Ran unit tests


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
