### PR TITLE
feat: Expose new `ApiEndpoints` class to return API endpoint URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/api-endpoint.spec.ts
+++ b/src/api-endpoint.spec.ts
@@ -1,0 +1,17 @@
+import ApiEndpoints from './api-endpoints';
+
+describe('ApiEndpoints', () => {
+  it('should append query parameters to the URL', () => {
+    const apiEndpoints = new ApiEndpoints('http://api.example.com', {
+      apiKey: '12345',
+      sdkVersion: 'foobar',
+      sdkName: 'ExampleSDK',
+    });
+    expect(apiEndpoints.endpoint('/data').toString()).toEqual(
+      'http://api.example.com/data?apiKey=12345&sdkVersion=foobar&sdkName=ExampleSDK',
+    );
+    expect(apiEndpoints.ufcEndpoint().toString()).toEqual(
+      'http://api.example.com/flag-config/v1/config?apiKey=12345&sdkVersion=foobar&sdkName=ExampleSDK',
+    );
+  });
+});

--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -1,0 +1,17 @@
+import { ISdkParams } from './http-client';
+
+const UFC_ENDPOINT = '/flag-config/v1/config';
+
+export default class ApiEndpoints {
+  constructor(private readonly baseUrl: string, private readonly queryParams: ISdkParams) {}
+
+  endpoint(resource: string): URL {
+    const url = new URL(this.baseUrl + resource);
+    Object.entries(this.queryParams).forEach(([key, value]) => url.searchParams.append(key, value));
+    return url;
+  }
+
+  ufcEndpoint(): URL {
+    return this.endpoint(UFC_ENDPOINT);
+  }
+}

--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -2,6 +2,7 @@ import { ISdkParams } from './http-client';
 
 const UFC_ENDPOINT = '/flag-config/v1/config';
 
+/** Utility class for constructing an Eppo API endpoint URL given a provided baseUrl and query parameters */
 export default class ApiEndpoints {
   constructor(private readonly baseUrl: string, private readonly queryParams: ISdkParams) {}
 

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -10,6 +10,7 @@ import {
   readMockUFCResponse,
   validateTestAssignments,
 } from '../../test/testHelpers';
+import ApiEndpoints from '../api-endpoints';
 import { IAssignmentLogger } from '../assignment-logger';
 import { IConfigurationStore } from '../configuration-store/configuration-store';
 import { MemoryOnlyConfigurationStore } from '../configuration-store/memory.store';
@@ -21,15 +22,12 @@ import { Flag, ObfuscatedFlag, VariationType } from '../interfaces';
 import EppoClient, { FlagConfigurationRequestParameters, checkTypeMatch } from './eppo-client';
 
 export async function init(configurationStore: IConfigurationStore<Flag | ObfuscatedFlag>) {
-  const httpClient = new FetchHttpClient(
-    'http://127.0.0.1:4000',
-    {
-      apiKey: 'dummy',
-      sdkName: 'js-client-sdk-common',
-      sdkVersion: '1.0.0',
-    },
-    1000,
-  );
+  const apiEndpoints = new ApiEndpoints('http://127.0.0.1:4000', {
+    apiKey: 'dummy',
+    sdkName: 'js-client-sdk-common',
+    sdkVersion: '1.0.0',
+  });
+  const httpClient = new FetchHttpClient(apiEndpoints, 1000);
   const configurationRequestor = new FlagConfigurationRequestor(configurationStore, httpClient);
   await configurationRequestor.fetchAndStoreConfigurations();
 }

--- a/src/flag-configuration-requestor.ts
+++ b/src/flag-configuration-requestor.ts
@@ -2,20 +2,15 @@ import { IConfigurationStore } from './configuration-store/configuration-store';
 import { IHttpClient } from './http-client';
 import { Flag } from './interfaces';
 
-const UFC_ENDPOINT = '/flag-config/v1/config';
-
-interface IUniversalFlagConfig {
-  flags: Record<string, Flag>;
-}
-
+// Requests AND stores flag configurations
 export default class FlagConfigurationRequestor {
   constructor(
-    private configurationStore: IConfigurationStore<Flag>,
-    private httpClient: IHttpClient,
+    private readonly configurationStore: IConfigurationStore<Flag>,
+    private readonly httpClient: IHttpClient,
   ) {}
 
   async fetchAndStoreConfigurations(): Promise<Record<string, Flag>> {
-    const responseData = await this.httpClient.get<IUniversalFlagConfig>(UFC_ENDPOINT);
+    const responseData = await this.httpClient.getUniversalFlagConfiguration();
     if (!responseData) {
       return {};
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import ApiEndpoints from './api-endpoints';
 import { logger } from './application-logger';
 import {
   Cacheable,
@@ -29,7 +28,6 @@ export {
   IAssignmentLogger,
   IAssignmentEvent,
   EppoClient,
-  ApiEndpoints,
   IEppoClient,
   constants,
   FlagConfigRequestor,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import ApiEndpoints from './api-endpoints';
 import { logger } from './application-logger';
 import {
   Cacheable,
@@ -28,6 +29,7 @@ export {
   IAssignmentLogger,
   IAssignmentEvent,
   EppoClient,
+  ApiEndpoints,
   IEppoClient,
   constants,
   FlagConfigRequestor,


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
This change extracts the API URL building portion out of `FetchHttpClient` into a new class called `ApiEndpoints` which is now exported and allows `js-client-sdk` to then expose the `UFC_ENDPOINT` full URL.

## Description
This is a straightforward refactoring with some decoupling and moving stuff out of `FetchHttpClient`. No functionality should have been changed. No API changes either other than exposing a new class.

Bumped minor version due to new external API being introduced.

## How has this been tested?
Existing and new tests


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
