### PR TITLE
FF-2139 Fix base64 encoding/decoding for React Native 0.72.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
   "homepage": "https://github.com/Eppo-exp/js-client-sdk-common#readme",
   "devDependencies": {
     "@types/jest": "^29.5.11",
+    "@types/js-base64": "^3.3.1",
     "@types/md5": "^2.3.2",
+    "@types/react-native-base64": "^0.2.2",
     "@types/semver": "^7.5.6",
     "@typescript-eslint/eslint-plugin": "^5.13.0",
     "@typescript-eslint/parser": "^5.13.0",
@@ -63,9 +65,9 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
+    "js-base64": "^3.7.7",
     "md5": "^2.3.0",
     "pino": "^8.19.0",
-    "semver": "^7.5.4",
-    "universal-base64": "^2.1.0"
+    "semver": "^7.5.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@types/jest": "^29.5.11",
     "@types/js-base64": "^3.3.1",
     "@types/md5": "^2.3.2",
-    "@types/react-native-base64": "^0.2.2",
     "@types/semver": "^7.5.6",
     "@typescript-eslint/eslint-plugin": "^5.13.0",
     "@typescript-eslint/parser": "^5.13.0",

--- a/src/obfuscation.ts
+++ b/src/obfuscation.ts
@@ -1,14 +1,14 @@
+import base64 = require('js-base64');
 import * as md5 from 'md5';
-import { decode, encode } from 'universal-base64';
 
 export function getMD5Hash(input: string): string {
   return md5(input);
 }
 
 export function encodeBase64(input: string) {
-  return encode(input);
+  return base64.btoaPolyfill(input);
 }
 
 export function decodeBase64(input: string) {
-  return decode(input);
+  return base64.atobPolyfill(input);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -747,6 +747,13 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
+"@types/js-base64@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/js-base64/-/js-base64-3.3.1.tgz#36c2d6dc126277ea28a4d0599d0cafbf547b51e6"
+  integrity sha512-Zw33oQNAvDdAN9b0IE5stH0y2MylYvtU7VVTKEJPxhyM2q57CVaNJhtJW258ah24NRtaiA23tptUmVn3dmTKpw==
+  dependencies:
+    js-base64 "*"
+
 "@types/jsdom@^20.0.0":
   version "20.0.1"
   resolved "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz"
@@ -777,6 +784,11 @@
   integrity sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==
   dependencies:
     undici-types "~5.26.4"
+
+"@types/react-native-base64@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@types/react-native-base64/-/react-native-base64-0.2.2.tgz#d4e1d537e6d547d23d96a1e64627acc13587ae6b"
+  integrity sha512-obr+/L9Jaxdr+xCVS/IQcYgreg5xtnui4Wqw/G1acBUtW2CnqVJj6lK6F/5F3+5d2oZEo5xDDLqy8GVn2HbEmw==
 
 "@types/semver@^7.5.6":
   version "7.5.6"
@@ -2934,6 +2946,11 @@ jest@^29.7.0:
     import-local "^3.0.2"
     jest-cli "^29.7.0"
 
+js-base64@*, js-base64@^3.7.7:
+  version "3.7.7"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.7.tgz#e51b84bf78fbf5702b9541e2cb7bfcb893b43e79"
+  integrity sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
@@ -4104,11 +4121,6 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
-
-universal-base64@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/universal-base64/-/universal-base64-2.1.0.tgz#511af92b3a07340fc2647036045aadb3bedcc320"
-  integrity sha512-WeOkACVnIXJZr/qlv7++Rl1zuZOHN96v2yS5oleUuv8eJOs5j9M5U3xQEIoWqn1OzIuIcgw0fswxWnUVGDfW6g==
 
 universalify@^0.2.0:
   version "0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -785,11 +785,6 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/react-native-base64@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@types/react-native-base64/-/react-native-base64-0.2.2.tgz#d4e1d537e6d547d23d96a1e64627acc13587ae6b"
-  integrity sha512-obr+/L9Jaxdr+xCVS/IQcYgreg5xtnui4Wqw/G1acBUtW2CnqVJj6lK6F/5F3+5d2oZEo5xDDLqy8GVn2HbEmw==
-
 "@types/semver@^7.5.6":
   version "7.5.6"
   resolved "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz"


### PR DESCRIPTION
---
labels: mergeable
---
Fixes [FF-2139](https://linear.app/eppo/issue/FF-2139)

## Motivation and Context
Fixes `Property 'atob' doesn't exist` error in React Native 0.72.x

## Description
`atob` and `btoa` are not built in to React Native's JS runtime for react-native 0.72. The `atob` and `btoa` were being used by the `universal-base64` package. Replacing this package with `js-base64` provides a [base64 implementation](https://github.com/dankogai/js-base64/blob/main/base64.js) that doesn't rely on atob, btoa or Buffer existing.

## How has this been tested?
- I was able to reproduce the issue by creating a RN 0.72.0 app and testing with XCode / Simulator
- I made the changes in this PR and recompiled assets to `dist`
- I copied over the changed `dist` files, along with the newly installed `js-base64` module to my `node_modules/@eppo/js-client-sdk-common/dist` folder and `node_modules/` folders respectively
- I rebuilt my RN app and no longer encountered the error
- I also verified the base64 implementation by encoding 'asdf' in a browser console via `btoa('asdf')` then decoding the result via the library.

## Before
<img width="332" alt="Screenshot 2024-06-06 at 7 25 49 AM" src="https://github.com/Eppo-exp/js-client-sdk-common/assets/1248641/5b00a2d3-157b-471b-9e23-7d0ec058679e">

## After
<img width="299" alt="Screenshot 2024-06-06 at 8 54 48 AM" src="https://github.com/Eppo-exp/js-client-sdk-common/assets/1248641/57d3595b-9d40-4681-b0f6-c4988ceaa53f">

