### PR TITLE
Revert "v3.2.1-bump v3.2.1 bump (#77)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "3.2.1",
+  "version": "3.2.0",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
This reverts commit 0f6cfdb162c9c56ab5f6458890ba29be757f7d18.

We skipped the v3.2.0 release, so I'm reverting this. We didn't end up cutting a release for v3.2.1 since a test was failing.