### PR TITLE
chore: Export `AbstractAssignmentCache`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/cache/assignment-cache.ts
+++ b/src/cache/assignment-cache.ts
@@ -20,7 +20,7 @@ export interface AssignmentCache {
   has(key: AssignmentCacheKey): boolean;
 }
 
-export abstract class AssignmentCacheImpl<T extends Map<string, string>>
+export abstract class AbstractAssignmentCache<T extends Map<string, string>>
   implements AssignmentCache
 {
   // key -> variation value hash
@@ -59,7 +59,9 @@ export abstract class AssignmentCacheImpl<T extends Map<string, string>>
  * The primary use case is for client-side SDKs, where the cache is only used
  * for a single user.
  */
-export class NonExpiringInMemoryAssignmentCache extends AssignmentCacheImpl<Map<string, string>> {
+export class NonExpiringInMemoryAssignmentCache extends AbstractAssignmentCache<
+  Map<string, string>
+> {
   constructor() {
     super(new Map<string, string>());
   }
@@ -74,7 +76,7 @@ export class NonExpiringInMemoryAssignmentCache extends AssignmentCacheImpl<Map<
  * multiple users. In this case, the cache size should be set to the maximum number
  * of users that can be active at the same time.
  */
-export class LRUInMemoryAssignmentCache extends AssignmentCacheImpl<LRUCache> {
+export class LRUInMemoryAssignmentCache extends AbstractAssignmentCache<LRUCache> {
   constructor(maxSize: number) {
     super(new LRUCache(maxSize));
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { logger } from './application-logger';
 import { IAssignmentHooks } from './assignment-hooks';
 import { IAssignmentLogger, IAssignmentEvent } from './assignment-logger';
 import {
+  AbstractAssignmentCache,
   AssignmentCache,
   NonExpiringInMemoryAssignmentCache,
   LRUInMemoryAssignmentCache,
@@ -24,6 +25,7 @@ import * as validation from './validation';
 
 export {
   logger as applicationLogger,
+  AbstractAssignmentCache,
   IAssignmentHooks,
   IAssignmentLogger,
   IAssignmentEvent,


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
This needs to be exported so users can implement custom assignment cache versions.
This will be used by js-client-sdk (PR incoming)

## Description
FF-2113

## How has this been tested?
Existing tests


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
