### PR TITLE
Aaron/ff 2407/bandit evaluator

### DIFF
--- a/src/bandit-evaluator.spec.ts
+++ b/src/bandit-evaluator.spec.ts
@@ -276,12 +276,12 @@ describe('BanditEvaluator', () => {
         gamma,
         highProbabilityFloor,
       );
-      // As we increase the probability floor, we expect the lowest scored action's weight to be lifted, and the others reduced to make room
+      // As we increase the probability floor, we expect the lowest scored action's weight to be lifted, the highest scored to be reduced, and the others to the stay the same
       // We also explicit all weights to be above the normalized probability floor, 0.3 / 3 = 0.1
-      expect(actionWeightsHighProbabilityFloor.action1).toBeLessThan(
+      expect(actionWeightsHighProbabilityFloor.action1).toBeLessThanOrEqual(
         actionWeightsLowProbabilityFloor.action1,
       );
-      expect(actionWeightsHighProbabilityFloor.action2).toBeLessThan(
+      expect(actionWeightsHighProbabilityFloor.action2).toBe(
         actionWeightsLowProbabilityFloor.action2,
       );
       expect(actionWeightsHighProbabilityFloor.action3).toBeGreaterThan(
@@ -292,7 +292,8 @@ describe('BanditEvaluator', () => {
         false,
       );
       expect(
-        Object.values(actionWeightsHighProbabilityFloor).every((weight) => weight >= 0.1),
+        // Since we know the floor will be in effect, we use > 0.09999 instead of >= 0.1 to account for lack of precision with floating point numbers
+        Object.values(actionWeightsHighProbabilityFloor).every((weight) => weight > 0.099999),
       ).toBe(true);
     });
   });

--- a/src/bandit-evaluator.spec.ts
+++ b/src/bandit-evaluator.spec.ts
@@ -120,7 +120,7 @@ describe('BanditEvaluator', () => {
       expect(score).toBe(expectedScore);
     });
 
-    it('Handles negative numeric coefficients', () => {
+    it('Handles negative categorical coefficients', () => {
       const negativeCategoricalCoefficients: BanditCategoricalAttributeCoefficients[] = [
         {
           attributeKey: 'color',

--- a/src/bandit-evaluator.spec.ts
+++ b/src/bandit-evaluator.spec.ts
@@ -1,0 +1,154 @@
+import { BanditEvaluator } from './bandit-evaluator';
+import {
+  BanditCategoricalAttributeCoefficients,
+  BanditModelData,
+  BanditNumericAttributeCoefficients,
+} from './interfaces';
+import { Attributes } from './types';
+
+describe('BanditEvaluator', () => {
+  const banditEvaluator = new BanditEvaluator();
+
+  describe('scoreActions', () => {
+    // We don't want these methods part of the public interface, however it's handy to be able to test them individually
+    const exposedEvaluator = banditEvaluator as unknown as {
+      scoreActions: (
+        subjectAttributes: Attributes,
+        actions: Record<string, Attributes>,
+        banditModel: BanditModelData,
+      ) => Record<string, number>;
+      scoreNumericAttributes: (
+        coefficients: BanditNumericAttributeCoefficients[],
+        attributes: Attributes,
+      ) => number;
+      scoreCategoricalAttributes: (
+        coefficients: BanditCategoricalAttributeCoefficients[],
+        attributes: Attributes,
+      ) => number;
+    };
+
+    describe('scoreNumericAttributes', () => {
+      const numericCoefficients: BanditNumericAttributeCoefficients[] = [
+        { attributeKey: 'age', coefficient: 2.0, missingValueCoefficient: 0.5 },
+        { attributeKey: 'height', coefficient: 1.5, missingValueCoefficient: 0.3 },
+      ];
+
+      it('Scores numeric attributes', () => {
+        const subjectAttributes: Attributes = { age: 30, height: 170 };
+        const expectedScore = 30 * 2.0 + 170 * 1.5;
+        const score = exposedEvaluator.scoreNumericAttributes(
+          numericCoefficients,
+          subjectAttributes,
+        );
+        expect(score).toBe(expectedScore);
+      });
+
+      it('Handles missing and extraneous numeric attributes', () => {
+        const subjectAttributes: Attributes = { age: 30, powerLevel: 9000 };
+        const expectedScore = 30 * 2.0 + 0.3;
+        const score = exposedEvaluator.scoreNumericAttributes(
+          numericCoefficients,
+          subjectAttributes,
+        );
+        expect(score).toBe(expectedScore);
+      });
+
+      it('Handles all numeric attributes missing', () => {
+        const subjectAttributes: Attributes = {};
+        const expectedScore = 0.5 + 0.3;
+        const score = exposedEvaluator.scoreNumericAttributes(
+          numericCoefficients,
+          subjectAttributes,
+        );
+        expect(score).toBe(expectedScore);
+      });
+
+      it('Handles negative numeric coefficients', () => {
+        const negativeNumericCoefficients: BanditNumericAttributeCoefficients[] = [
+          { attributeKey: 'age', coefficient: -2.0, missingValueCoefficient: 0.5 },
+          { attributeKey: 'height', coefficient: -1.5, missingValueCoefficient: 0.3 },
+        ];
+        const subjectAttributes: Attributes = { age: 30, height: 170 };
+        const expectedScore = 30 * -2.0 + 170 * -1.5;
+        const score = exposedEvaluator.scoreNumericAttributes(
+          negativeNumericCoefficients,
+          subjectAttributes,
+        );
+        expect(score).toBe(expectedScore);
+      });
+    });
+
+    describe('scoreCategoricalAttributes', () => {
+      const categoricalCoefficients: BanditCategoricalAttributeCoefficients[] = [
+        {
+          attributeKey: 'color',
+          missingValueCoefficient: 0.2,
+          valueCoefficients: {
+            red: 1.0,
+            blue: 0.5,
+          },
+        },
+        {
+          attributeKey: 'size',
+          missingValueCoefficient: 0.3,
+          valueCoefficients: { large: 2.0, small: 1.0 },
+        },
+      ];
+
+      it('Scores categorical coefficients', () => {
+        const subjectAttributes: Attributes = { color: 'blue', size: 'large' };
+        const expectedScore = 0.5 + 2.0;
+        const score = exposedEvaluator.scoreCategoricalAttributes(
+          categoricalCoefficients,
+          subjectAttributes,
+        );
+        expect(score).toBe(expectedScore);
+      });
+
+      it('Handles missing, extraneous, and unrecognized categorical coefficients', () => {
+        const subjectAttributes: Attributes = { color: 'red', size: 'zero', state: 'CO' };
+        const expectedScore = 1 + 0.3;
+        const score = exposedEvaluator.scoreCategoricalAttributes(
+          categoricalCoefficients,
+          subjectAttributes,
+        );
+        expect(score).toBe(expectedScore);
+      });
+
+      it('Handles all categorical attributes missing', () => {
+        const subjectAttributes: Attributes = {};
+        const expectedScore = 0.2 + 0.3;
+        const score = exposedEvaluator.scoreCategoricalAttributes(
+          categoricalCoefficients,
+          subjectAttributes,
+        );
+        expect(score).toBe(expectedScore);
+      });
+
+      it('Handles negative numeric coefficients', () => {
+        const negativeCategoricalCoefficients: BanditCategoricalAttributeCoefficients[] = [
+          {
+            attributeKey: 'color',
+            missingValueCoefficient: 0.2,
+            valueCoefficients: {
+              red: 1.0,
+              blue: 0.5,
+            },
+          },
+          {
+            attributeKey: 'size',
+            missingValueCoefficient: 0.3,
+            valueCoefficients: { large: 2.0, small: 1.0 },
+          },
+        ];
+        const subjectAttributes: Attributes = { color: 'blue', size: 'small' };
+        const expectedScore = -0.5 + -1.0;
+        const score = exposedEvaluator.scoreCategoricalAttributes(
+          negativeCategoricalCoefficients,
+          subjectAttributes,
+        );
+        expect(score).toBe(expectedScore);
+      });
+    });
+  });
+});

--- a/src/bandit-evaluator.spec.ts
+++ b/src/bandit-evaluator.spec.ts
@@ -129,16 +129,16 @@ describe('BanditEvaluator', () => {
         const negativeCategoricalCoefficients: BanditCategoricalAttributeCoefficients[] = [
           {
             attributeKey: 'color',
-            missingValueCoefficient: 0.2,
+            missingValueCoefficient: -0.2,
             valueCoefficients: {
-              red: 1.0,
-              blue: 0.5,
+              red: -1.0,
+              blue: -0.5,
             },
           },
           {
             attributeKey: 'size',
-            missingValueCoefficient: 0.3,
-            valueCoefficients: { large: 2.0, small: 1.0 },
+            missingValueCoefficient: -0.3,
+            valueCoefficients: { large: -2.0, small: -1.0 },
           },
         ];
         const subjectAttributes: Attributes = { color: 'blue', size: 'small' };

--- a/src/bandit-evaluator.spec.ts
+++ b/src/bandit-evaluator.spec.ts
@@ -9,146 +9,205 @@ import { Attributes } from './types';
 describe('BanditEvaluator', () => {
   const banditEvaluator = new BanditEvaluator();
 
-  describe('scoreActions', () => {
-    // We don't want these methods part of the public interface, however it's handy to be able to test them individually
-    const exposedEvaluator = banditEvaluator as unknown as {
-      scoreActions: (
-        subjectAttributes: Attributes,
-        actions: Record<string, Attributes>,
-        banditModel: BanditModelData,
-      ) => Record<string, number>;
-      scoreNumericAttributes: (
-        coefficients: BanditNumericAttributeCoefficients[],
-        attributes: Attributes,
-      ) => number;
-      scoreCategoricalAttributes: (
-        coefficients: BanditCategoricalAttributeCoefficients[],
-        attributes: Attributes,
-      ) => number;
-    };
+  // We don't want these methods part of the public interface, however it's handy to be able to test them individually
+  const exposedEvaluator = banditEvaluator as unknown as {
+    scoreActions: (
+      subjectAttributes: Attributes,
+      actions: Record<string, Attributes>,
+      banditModel: Pick<BanditModelData, 'coefficients' | 'defaultActionScore'>,
+    ) => Record<string, number>;
+    scoreNumericAttributes: (
+      coefficients: BanditNumericAttributeCoefficients[],
+      attributes: Attributes,
+    ) => number;
+    scoreCategoricalAttributes: (
+      coefficients: BanditCategoricalAttributeCoefficients[],
+      attributes: Attributes,
+    ) => number;
+  };
 
-    describe('scoreNumericAttributes', () => {
-      const numericCoefficients: BanditNumericAttributeCoefficients[] = [
-        { attributeKey: 'age', coefficient: 2.0, missingValueCoefficient: 0.5 },
-        { attributeKey: 'height', coefficient: 1.5, missingValueCoefficient: 0.3 },
-      ];
+  describe('scoreNumericAttributes', () => {
+    const numericCoefficients: BanditNumericAttributeCoefficients[] = [
+      { attributeKey: 'age', coefficient: 2.0, missingValueCoefficient: 0.5 },
+      { attributeKey: 'height', coefficient: 1.5, missingValueCoefficient: 0.3 },
+    ];
 
-      it('Scores numeric attributes', () => {
-        const subjectAttributes: Attributes = { age: 30, height: 170 };
-        const expectedScore = 30 * 2.0 + 170 * 1.5;
-        const score = exposedEvaluator.scoreNumericAttributes(
-          numericCoefficients,
-          subjectAttributes,
-        );
-        expect(score).toBe(expectedScore);
-      });
-
-      it('Handles missing and extraneous numeric attributes', () => {
-        const subjectAttributes: Attributes = { age: 30, powerLevel: 9000 };
-        const expectedScore = 30 * 2.0 + 0.3;
-        const score = exposedEvaluator.scoreNumericAttributes(
-          numericCoefficients,
-          subjectAttributes,
-        );
-        expect(score).toBe(expectedScore);
-      });
-
-      it('Handles all numeric attributes missing', () => {
-        const subjectAttributes: Attributes = {};
-        const expectedScore = 0.5 + 0.3;
-        const score = exposedEvaluator.scoreNumericAttributes(
-          numericCoefficients,
-          subjectAttributes,
-        );
-        expect(score).toBe(expectedScore);
-      });
-
-      it('Handles negative numeric coefficients', () => {
-        const negativeNumericCoefficients: BanditNumericAttributeCoefficients[] = [
-          { attributeKey: 'age', coefficient: -2.0, missingValueCoefficient: 0.5 },
-          { attributeKey: 'height', coefficient: -1.5, missingValueCoefficient: 0.3 },
-        ];
-        const subjectAttributes: Attributes = { age: 30, height: 170 };
-        const expectedScore = 30 * -2.0 + 170 * -1.5;
-        const score = exposedEvaluator.scoreNumericAttributes(
-          negativeNumericCoefficients,
-          subjectAttributes,
-        );
-        expect(score).toBe(expectedScore);
-      });
+    it('Scores numeric attributes', () => {
+      const subjectAttributes: Attributes = { age: 30, height: 170 };
+      const expectedScore = 30 * 2.0 + 170 * 1.5;
+      const score = exposedEvaluator.scoreNumericAttributes(numericCoefficients, subjectAttributes);
+      expect(score).toBe(expectedScore);
     });
 
-    describe('scoreCategoricalAttributes', () => {
-      const categoricalCoefficients: BanditCategoricalAttributeCoefficients[] = [
+    it('Handles missing and extraneous numeric attributes', () => {
+      const subjectAttributes: Attributes = { age: 30, powerLevel: 9000 };
+      const expectedScore = 30 * 2.0 + 0.3;
+      const score = exposedEvaluator.scoreNumericAttributes(numericCoefficients, subjectAttributes);
+      expect(score).toBe(expectedScore);
+    });
+
+    it('Handles all numeric attributes missing', () => {
+      const subjectAttributes: Attributes = {};
+      const expectedScore = 0.5 + 0.3;
+      const score = exposedEvaluator.scoreNumericAttributes(numericCoefficients, subjectAttributes);
+      expect(score).toBe(expectedScore);
+    });
+
+    it('Handles negative numeric coefficients', () => {
+      const negativeNumericCoefficients: BanditNumericAttributeCoefficients[] = [
+        { attributeKey: 'age', coefficient: -2.0, missingValueCoefficient: 0.5 },
+        { attributeKey: 'height', coefficient: -1.5, missingValueCoefficient: 0.3 },
+      ];
+      const subjectAttributes: Attributes = { age: 30, height: 170 };
+      const expectedScore = 30 * -2.0 + 170 * -1.5;
+      const score = exposedEvaluator.scoreNumericAttributes(
+        negativeNumericCoefficients,
+        subjectAttributes,
+      );
+      expect(score).toBe(expectedScore);
+    });
+  });
+
+  describe('scoreCategoricalAttributes', () => {
+    const categoricalCoefficients: BanditCategoricalAttributeCoefficients[] = [
+      {
+        attributeKey: 'color',
+        missingValueCoefficient: 0.2,
+        valueCoefficients: {
+          red: 1.0,
+          blue: 0.5,
+        },
+      },
+      {
+        attributeKey: 'size',
+        missingValueCoefficient: 0.3,
+        valueCoefficients: { large: 2.0, small: 1.0 },
+      },
+    ];
+
+    it('Scores categorical coefficients', () => {
+      const subjectAttributes: Attributes = { color: 'blue', size: 'large' };
+      const expectedScore = 0.5 + 2.0;
+      const score = exposedEvaluator.scoreCategoricalAttributes(
+        categoricalCoefficients,
+        subjectAttributes,
+      );
+      expect(score).toBe(expectedScore);
+    });
+
+    it('Handles missing, extraneous, and unrecognized categorical coefficients', () => {
+      const subjectAttributes: Attributes = { color: 'red', size: 'zero', state: 'CO' };
+      const expectedScore = 1 + 0.3;
+      const score = exposedEvaluator.scoreCategoricalAttributes(
+        categoricalCoefficients,
+        subjectAttributes,
+      );
+      expect(score).toBe(expectedScore);
+    });
+
+    it('Handles all categorical attributes missing', () => {
+      const subjectAttributes: Attributes = {};
+      const expectedScore = 0.2 + 0.3;
+      const score = exposedEvaluator.scoreCategoricalAttributes(
+        categoricalCoefficients,
+        subjectAttributes,
+      );
+      expect(score).toBe(expectedScore);
+    });
+
+    it('Handles negative numeric coefficients', () => {
+      const negativeCategoricalCoefficients: BanditCategoricalAttributeCoefficients[] = [
         {
           attributeKey: 'color',
-          missingValueCoefficient: 0.2,
+          missingValueCoefficient: -0.2,
           valueCoefficients: {
-            red: 1.0,
-            blue: 0.5,
+            red: -1.0,
+            blue: -0.5,
           },
         },
         {
           attributeKey: 'size',
-          missingValueCoefficient: 0.3,
-          valueCoefficients: { large: 2.0, small: 1.0 },
+          missingValueCoefficient: -0.3,
+          valueCoefficients: { large: -2.0, small: -1.0 },
         },
       ];
+      const subjectAttributes: Attributes = { color: 'blue', size: 'small' };
+      const expectedScore = -0.5 + -1.0;
+      const score = exposedEvaluator.scoreCategoricalAttributes(
+        negativeCategoricalCoefficients,
+        subjectAttributes,
+      );
+      expect(score).toBe(expectedScore);
+    });
+  });
 
-      it('Scores categorical coefficients', () => {
-        const subjectAttributes: Attributes = { color: 'blue', size: 'large' };
-        const expectedScore = 0.5 + 2.0;
-        const score = exposedEvaluator.scoreCategoricalAttributes(
-          categoricalCoefficients,
-          subjectAttributes,
-        );
-        expect(score).toBe(expectedScore);
-      });
-
-      it('Handles missing, extraneous, and unrecognized categorical coefficients', () => {
-        const subjectAttributes: Attributes = { color: 'red', size: 'zero', state: 'CO' };
-        const expectedScore = 1 + 0.3;
-        const score = exposedEvaluator.scoreCategoricalAttributes(
-          categoricalCoefficients,
-          subjectAttributes,
-        );
-        expect(score).toBe(expectedScore);
-      });
-
-      it('Handles all categorical attributes missing', () => {
-        const subjectAttributes: Attributes = {};
-        const expectedScore = 0.2 + 0.3;
-        const score = exposedEvaluator.scoreCategoricalAttributes(
-          categoricalCoefficients,
-          subjectAttributes,
-        );
-        expect(score).toBe(expectedScore);
-      });
-
-      it('Handles negative numeric coefficients', () => {
-        const negativeCategoricalCoefficients: BanditCategoricalAttributeCoefficients[] = [
-          {
-            attributeKey: 'color',
-            missingValueCoefficient: -0.2,
-            valueCoefficients: {
-              red: -1.0,
-              blue: -0.5,
+  describe('scoreActions', () => {
+    const modelData: Pick<BanditModelData, 'coefficients' | 'defaultActionScore'> = {
+      defaultActionScore: 1.23,
+      coefficients: {
+        action1: {
+          actionKey: 'action1',
+          intercept: 0.5,
+          subjectNumericCoefficients: [
+            { attributeKey: 'age', coefficient: 0.1, missingValueCoefficient: 0.0 },
+          ],
+          subjectCategoricalCoefficients: [
+            {
+              attributeKey: 'location',
+              missingValueCoefficient: 0.0,
+              valueCoefficients: { US: 0.2 },
             },
-          },
-          {
-            attributeKey: 'size',
-            missingValueCoefficient: -0.3,
-            valueCoefficients: { large: -2.0, small: -1.0 },
-          },
-        ];
-        const subjectAttributes: Attributes = { color: 'blue', size: 'small' };
-        const expectedScore = -0.5 + -1.0;
-        const score = exposedEvaluator.scoreCategoricalAttributes(
-          negativeCategoricalCoefficients,
-          subjectAttributes,
-        );
-        expect(score).toBe(expectedScore);
-      });
+          ],
+          actionNumericCoefficients: [
+            { attributeKey: 'price', coefficient: 0.05, missingValueCoefficient: 0.0 },
+          ],
+          actionCategoricalCoefficients: [
+            {
+              attributeKey: 'category',
+              missingValueCoefficient: 0.0,
+              valueCoefficients: { A: 0.3 },
+            },
+          ],
+        },
+        action2: {
+          actionKey: 'action2',
+          intercept: 0.3,
+          subjectNumericCoefficients: [
+            { attributeKey: 'age', coefficient: 0.2, missingValueCoefficient: 0.3 },
+          ],
+          subjectCategoricalCoefficients: [
+            {
+              attributeKey: 'color',
+              missingValueCoefficient: 0.6,
+              valueCoefficients: { red: 0.4 },
+            },
+          ],
+          actionNumericCoefficients: [
+            { attributeKey: 'price', coefficient: -0.1, missingValueCoefficient: 0.0 },
+          ],
+          actionCategoricalCoefficients: [
+            {
+              attributeKey: 'category',
+              missingValueCoefficient: -0.2,
+              valueCoefficients: { B: 0.4 },
+            },
+          ],
+        },
+      },
+    };
+
+    it('scores each action', () => {
+      const subjectAttributes: Attributes = { age: 30, location: 'US' };
+      const actions: Record<string, Attributes> = {
+        action1: { price: 25, category: 'A' },
+        action2: { price: 50, category: 'B' },
+        action99: { price: 100, category: 'C' },
+      };
+      const actionScores = exposedEvaluator.scoreActions(subjectAttributes, actions, modelData);
+      expect(Object.keys(actionScores)).toHaveLength(3);
+      expect(actionScores.action1).toBe(0.5 + 30 * 0.1 + 0.2 + 25 * 0.05 + 0.3);
+      expect(actionScores.action2).toBe(0.3 + 30 * 0.2 + 0.6 + -0.1 * 50 + 0.4);
+      expect(actionScores.action99).toBe(1.23); // Default score
     });
   });
 });

--- a/src/bandit-evaluator.ts
+++ b/src/bandit-evaluator.ts
@@ -1,4 +1,4 @@
-import { BanditModelData } from './interfaces';
+import { BanditModelData, BanditNumericAttributeCoefficients } from './interfaces';
 import { Attributes } from './types';
 
 export interface BanditEvaluation {
@@ -54,6 +54,14 @@ export class BanditEvaluator {
       actionScores[actionKey] = score;
     });
     return actionScores;
+  }
+
+  private scoreNumericAttributes(coefficients: BanditNumericAttributeCoefficients[], attributes: Attributes): number {
+    return 0;// TODO: math
+  }
+
+  private scoreCategoricalAttributes(coefficients: BanditNumericAttributeCoefficients[], attributes: Attributes): number {
+    return 0;// TODO: math
   }
 
   private weighActions(actionScores: Record<string, number>, gamma: number, actionProbabilityFloor: number) {

--- a/src/bandit-evaluator.ts
+++ b/src/bandit-evaluator.ts
@@ -1,0 +1,71 @@
+import { BanditModelData } from './interfaces';
+import { Attributes } from './types';
+
+export interface BanditEvaluation {
+  flagKey: string;
+  subjectKey: string;
+  subjectAttributes: Attributes;
+  actionKey: string;
+  actionAttributes: Attributes;
+  actionScore: number;
+  actionWeight: number;
+  gamma: number;
+  optimalityGap: number;
+}
+
+export class BanditEvaluator {
+  public evaluateBandit(
+    flagKey: string,
+    subjectKey: string,
+    subjectAttributes: Attributes,
+    actions: Record<string, Attributes>,
+    banditModel: BanditModelData,
+  ): BanditEvaluation {
+    const actionScores: Record<string, number> = this.scoreActions(
+      subjectAttributes,
+      actions,
+      banditModel,
+    );
+    const actionWeights: Record<string, number> = this.weighActions(
+      actionScores,
+      banditModel.gamma,
+      banditModel.actionProbabilityFloor,
+    );
+    const selectedActionKey: string = this.selectAction(flagKey, subjectKey, actionWeights);
+    const optimalityGap = 0; // TODO: compute difference between selected and max
+
+    return {
+      flagKey,
+      subjectKey,
+      subjectAttributes,
+      actionKey: selectedActionKey,
+      actionAttributes: actions[selectedActionKey],
+      actionScore: actionScores[selectedActionKey],
+      actionWeight: actionWeights[selectedActionKey],
+      gamma: banditModel.gamma,
+      optimalityGap,
+    };
+  }
+
+  private scoreActions(subjectAttributes: Attributes, actions: Record<string, Attributes>, banditModel: BanditModelData): Record<string, number> {
+    const actionScores: Record<string, number> = {};
+    Object.entries(actions).forEach(([actionKey, actionAttributes]) => {
+      const score = 0; // TODO: math
+      actionScores[actionKey] = score;
+    });
+    return actionScores;
+  }
+
+  private weighActions(actionScores: Record<string, number>, gamma: number, actionProbabilityFloor: number) {
+    const actionWeights: Record<string, number> = {};
+    Object.entries(actionScores).forEach(([actionKey, actionScore]) => {
+      const weight = 0; // TODO: math
+      actionWeights[actionKey] = weight;
+    });
+    return actionWeights;
+  }
+
+  private selectAction(flagKey: string, subjectKey: string, actionWeights: Record<string, number>): string {
+    return Object.keys(actionWeights)[0]; // TODO: math
+  }
+}

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -28,11 +28,7 @@ export async function init(configurationStore: IConfigurationStore<Flag | Obfusc
     sdkVersion: '1.0.0',
   });
   const httpClient = new FetchHttpClient(apiEndpoints, 1000);
-  const configurationRequestor = new ConfigurationRequestor(
-    httpClient,
-    configurationStore,
-    null,
-  );
+  const configurationRequestor = new ConfigurationRequestor(httpClient, configurationStore, null);
   await configurationRequestor.fetchAndStoreConfigurations();
 }
 

--- a/src/configuration-requestor.spec.ts
+++ b/src/configuration-requestor.spec.ts
@@ -189,7 +189,7 @@ describe('ConfigurationRequestor', () => {
     });
 
     it('Will not fetch bandit parameters if there is no store', async () => {
-      configurationRequestor = new ConfigurationRequestor(httpClient, flagStore, undefined);
+      configurationRequestor = new ConfigurationRequestor(httpClient, flagStore, null);
       await configurationRequestor.fetchAndStoreConfigurations();
       expect(fetchSpy).toHaveBeenCalledTimes(1);
     });

--- a/src/configuration-requestor.spec.ts
+++ b/src/configuration-requestor.spec.ts
@@ -9,12 +9,13 @@ import ApiEndpoints from './api-endpoints';
 import ConfigurationRequestor from './configuration-requestor';
 import { IConfigurationStore } from './configuration-store/configuration-store';
 import { MemoryOnlyConfigurationStore } from './configuration-store/memory.store';
-import FetchHttpClient from './http-client';
+import FetchHttpClient, { IHttpClient } from './http-client';
 import { BanditParameters, Flag } from './interfaces';
 
 describe('ConfigurationRequestor', () => {
   let flagStore: IConfigurationStore<Flag>;
   let banditStore: IConfigurationStore<BanditParameters>;
+  let httpClient: IHttpClient;
   let configurationRequestor: ConfigurationRequestor;
 
   beforeEach(async () => {
@@ -23,152 +24,174 @@ describe('ConfigurationRequestor', () => {
       sdkName: 'js-client-sdk-common',
       sdkVersion: '1.0.0',
     });
-    const httpClient = new FetchHttpClient(apiEndpoints, 1000);
+    httpClient = new FetchHttpClient(apiEndpoints, 1000);
     flagStore = new MemoryOnlyConfigurationStore<Flag>();
     banditStore = new MemoryOnlyConfigurationStore<BanditParameters>();
     configurationRequestor = new ConfigurationRequestor(httpClient, flagStore, banditStore);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   afterAll(() => {
     jest.restoreAllMocks();
   });
 
-  it('Fetches and stores flag configuration', async () => {
-    const fetchSpy = jest.fn(() => {
-      const response = readMockUFCResponse(MOCK_UFC_RESPONSE_FILE);
-      return Promise.resolve({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve(response),
+  describe('Flags with no bandits', () => {
+    let fetchSpy: jest.Mock;
+
+    beforeAll(() => {
+      fetchSpy = jest.fn(() => {
+        const response = readMockUFCResponse(MOCK_UFC_RESPONSE_FILE);
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(response),
+        });
+      }) as jest.Mock;
+      global.fetch = fetchSpy;
+    });
+
+    it('Fetches and stores flag configuration', async () => {
+      await configurationRequestor.fetchAndStoreConfigurations();
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1); // Flags only; no bandits
+
+      expect(flagStore.getKeys().length).toBeGreaterThanOrEqual(16);
+      const killSwitchFlag = flagStore.get('kill-switch');
+      expect(killSwitchFlag?.key).toBe('kill-switch');
+      expect(killSwitchFlag?.enabled).toBe(true);
+      expect(killSwitchFlag?.variationType).toBe('BOOLEAN');
+      expect(killSwitchFlag?.totalShards).toBe(10000);
+      expect(Object.keys(killSwitchFlag?.variations || {})).toHaveLength(2);
+      expect(killSwitchFlag?.variations['on']).toStrictEqual({
+        key: 'on',
+        value: true,
       });
-    }) as jest.Mock;
-    global.fetch = fetchSpy;
+      expect(killSwitchFlag?.variations['off']).toStrictEqual({
+        key: 'off',
+        value: false,
+      });
+      expect(killSwitchFlag?.allocations).toHaveLength(3);
+      const fiftyPlusAllocation = killSwitchFlag?.allocations[1];
+      expect(fiftyPlusAllocation?.key).toBe('on-for-age-50+');
+      expect(fiftyPlusAllocation?.doLog).toBe(true);
+      expect(fiftyPlusAllocation?.rules).toHaveLength(1);
+      expect(fiftyPlusAllocation?.rules?.[0].conditions).toHaveLength(1);
+      expect(fiftyPlusAllocation?.rules?.[0].conditions[0]).toStrictEqual({
+        attribute: 'age',
+        operator: 'GTE',
+        value: 50,
+      });
+      expect(fiftyPlusAllocation?.splits).toHaveLength(1);
+      expect(fiftyPlusAllocation?.splits[0].variationKey).toBe('on');
+      expect(fiftyPlusAllocation?.splits[0].shards).toHaveLength(1);
+      expect(fiftyPlusAllocation?.splits[0].shards[0].salt).toBe('some-salt');
+      expect(fiftyPlusAllocation?.splits[0].shards[0].ranges).toHaveLength(1);
+      expect(fiftyPlusAllocation?.splits[0].shards[0].ranges[0]).toStrictEqual({
+        start: 0,
+        end: 10000,
+      });
 
-    await configurationRequestor.fetchAndStoreConfigurations();
-
-    expect(fetchSpy).toHaveBeenCalledTimes(1); // Flags only; no bandits
-
-    expect(flagStore.getKeys().length).toBeGreaterThanOrEqual(16);
-    const killSwitchFlag = flagStore.get('kill-switch');
-    expect(killSwitchFlag?.key).toBe('kill-switch');
-    expect(killSwitchFlag?.enabled).toBe(true);
-    expect(killSwitchFlag?.variationType).toBe('BOOLEAN');
-    expect(killSwitchFlag?.totalShards).toBe(10000);
-    expect(Object.keys(killSwitchFlag?.variations || {})).toHaveLength(2);
-    expect(killSwitchFlag?.variations['on']).toStrictEqual({
-      key: 'on',
-      value: true,
+      expect(banditStore.getKeys().length).toBe(0);
     });
-    expect(killSwitchFlag?.variations['off']).toStrictEqual({
-      key: 'off',
-      value: false,
-    });
-    expect(killSwitchFlag?.allocations).toHaveLength(3);
-    const fiftyPlusAllocation = killSwitchFlag?.allocations[1];
-    expect(fiftyPlusAllocation?.key).toBe('on-for-age-50+');
-    expect(fiftyPlusAllocation?.doLog).toBe(true);
-    expect(fiftyPlusAllocation?.rules).toHaveLength(1);
-    expect(fiftyPlusAllocation?.rules?.[0].conditions).toHaveLength(1);
-    expect(fiftyPlusAllocation?.rules?.[0].conditions[0]).toStrictEqual({
-      attribute: 'age',
-      operator: 'GTE',
-      value: 50,
-    });
-    expect(fiftyPlusAllocation?.splits).toHaveLength(1);
-    expect(fiftyPlusAllocation?.splits[0].variationKey).toBe('on');
-    expect(fiftyPlusAllocation?.splits[0].shards).toHaveLength(1);
-    expect(fiftyPlusAllocation?.splits[0].shards[0].salt).toBe('some-salt');
-    expect(fiftyPlusAllocation?.splits[0].shards[0].ranges).toHaveLength(1);
-    expect(fiftyPlusAllocation?.splits[0].shards[0].ranges[0]).toStrictEqual({
-      start: 0,
-      end: 10000,
-    });
-
-    expect(banditStore.getKeys().length).toBe(0);
   });
 
-  it('Fetches and populates bandit parameters', async () => {
-    const fetchSpy = jest.fn((url: string) => {
-      const responseFile = url.includes('bandits')
-        ? MOCK_BANDIT_MODELS_RESPONSE_FILE
-        : MOCK_FLAGS_WITH_BANDITS_RESPONSE_FILE;
-      const response = readMockUFCResponse(responseFile);
+  describe('Flags with bandits', () => {
+    let fetchSpy: jest.Mock;
 
-      return Promise.resolve({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve(response),
+    beforeAll(() => {
+      fetchSpy = jest.fn((url: string) => {
+        const responseFile = url.includes('bandits')
+          ? MOCK_BANDIT_MODELS_RESPONSE_FILE
+          : MOCK_FLAGS_WITH_BANDITS_RESPONSE_FILE;
+        const response = readMockUFCResponse(responseFile);
+
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(response),
+        });
+      }) as jest.Mock;
+      global.fetch = fetchSpy;
+    });
+
+    it('Fetches and populates bandit parameters', async () => {
+      await configurationRequestor.fetchAndStoreConfigurations();
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2); // Once for UFC, another for bandits
+
+      expect(flagStore.getKeys().length).toBeGreaterThanOrEqual(2);
+      expect(flagStore.get('banner_bandit_flag')).toBeDefined();
+      expect(flagStore.get('cold_start_bandit')).toBeDefined();
+
+      expect(banditStore.getKeys().length).toBeGreaterThanOrEqual(2);
+
+      const bannerBandit = banditStore.get('banner_bandit');
+      expect(bannerBandit?.banditKey).toBe('banner_bandit');
+      expect(bannerBandit?.modelName).toBe('falcon');
+      expect(bannerBandit?.modelVersion).toBe('v123');
+      const bannerModelData = bannerBandit?.modelData;
+      expect(bannerModelData?.gamma).toBe(1);
+      expect(bannerModelData?.defaultActionScore).toBe(0);
+      expect(bannerModelData?.actionProbabilityFloor).toBe(0);
+      const bannerCoefficients = bannerModelData?.coefficients || {};
+      expect(Object.keys(bannerCoefficients).length).toBe(2);
+
+      // Deep dive for the nike action
+      const nikeCoefficients = bannerCoefficients['nike'];
+      expect(nikeCoefficients.actionKey).toBe('nike');
+      expect(nikeCoefficients.intercept).toBe(1);
+      expect(nikeCoefficients.actionNumericCoefficients).toHaveLength(1);
+      const nikeBrandAffinityCoefficient = nikeCoefficients.actionNumericCoefficients[0];
+      expect(nikeBrandAffinityCoefficient.attributeKey).toBe('brand_affinity');
+      expect(nikeBrandAffinityCoefficient.coefficient).toBe(1);
+      expect(nikeBrandAffinityCoefficient.missingValueCoefficient).toBe(-0.1);
+      expect(nikeCoefficients.actionCategoricalCoefficients).toHaveLength(1);
+      const nikeLoyaltyTierCoefficient = nikeCoefficients.actionCategoricalCoefficients[0];
+      expect(nikeLoyaltyTierCoefficient.attributeKey).toBe('loyalty_tier');
+      expect(nikeLoyaltyTierCoefficient.missingValueCoefficient).toBe(0);
+      expect(nikeLoyaltyTierCoefficient.valueCoefficients).toStrictEqual({
+        gold: 4.5,
+        silver: 3.2,
+        bronze: 1.9,
       });
-    }) as jest.Mock;
-    global.fetch = fetchSpy;
+      expect(nikeCoefficients.subjectNumericCoefficients).toHaveLength(1);
+      const nikeAccountAgeCoefficient = nikeCoefficients.subjectNumericCoefficients[0];
+      expect(nikeAccountAgeCoefficient.attributeKey).toBe('account_age');
+      expect(nikeAccountAgeCoefficient.coefficient).toBe(0.3);
+      expect(nikeAccountAgeCoefficient.missingValueCoefficient).toBe(0);
+      expect(nikeCoefficients.subjectCategoricalCoefficients).toHaveLength(1);
+      const nikeGenderIdentityCoefficient = nikeCoefficients.subjectCategoricalCoefficients[0];
+      expect(nikeGenderIdentityCoefficient.attributeKey).toBe('gender_identity');
+      expect(nikeGenderIdentityCoefficient.missingValueCoefficient).toBe(2.3);
+      expect(nikeGenderIdentityCoefficient.valueCoefficients).toStrictEqual({
+        female: 0.5,
+        male: -0.5,
+      });
 
-    await configurationRequestor.fetchAndStoreConfigurations();
+      // Just spot check the adidas parameters
+      expect(bannerCoefficients['adidas'].subjectNumericCoefficients).toHaveLength(0);
+      expect(
+        bannerCoefficients['adidas'].subjectCategoricalCoefficients[0].valueCoefficients['female'],
+      ).toBe(0);
 
-    expect(fetchSpy).toHaveBeenCalledTimes(2); // Once for UFC, another for bandits
-
-    expect(flagStore.getKeys().length).toBeGreaterThanOrEqual(2);
-    expect(flagStore.get('banner_bandit_flag')).toBeDefined();
-    expect(flagStore.get('cold_start_bandit')).toBeDefined();
-
-    expect(banditStore.getKeys().length).toBeGreaterThanOrEqual(2);
-
-    const bannerBandit = banditStore.get('banner_bandit');
-    expect(bannerBandit?.banditKey).toBe('banner_bandit');
-    expect(bannerBandit?.modelName).toBe('falcon');
-    expect(bannerBandit?.modelVersion).toBe('v123');
-    const bannerModelData = bannerBandit?.modelData;
-    expect(bannerModelData?.gamma).toBe(1);
-    expect(bannerModelData?.defaultActionScore).toBe(0);
-    expect(bannerModelData?.actionProbabilityFloor).toBe(0);
-    const bannerCoefficients = bannerModelData?.coefficients || {};
-    expect(Object.keys(bannerCoefficients).length).toBe(2);
-
-    // Deep dive for the nike action
-    const nikeCoefficients = bannerCoefficients['nike'];
-    expect(nikeCoefficients.actionKey).toBe('nike');
-    expect(nikeCoefficients.intercept).toBe(1);
-    expect(nikeCoefficients.actionNumericCoefficients).toHaveLength(1);
-    const nikeBrandAffinityCoefficient = nikeCoefficients.actionNumericCoefficients[0];
-    expect(nikeBrandAffinityCoefficient.attributeKey).toBe('brand_affinity');
-    expect(nikeBrandAffinityCoefficient.coefficient).toBe(1);
-    expect(nikeBrandAffinityCoefficient.missingValueCoefficient).toBe(-0.1);
-    expect(nikeCoefficients.actionCategoricalCoefficients).toHaveLength(1);
-    const nikeLoyaltyTierCoefficient = nikeCoefficients.actionCategoricalCoefficients[0];
-    expect(nikeLoyaltyTierCoefficient.attributeKey).toBe('loyalty_tier');
-    expect(nikeLoyaltyTierCoefficient.missingValueCoefficient).toBe(0);
-    expect(nikeLoyaltyTierCoefficient.valueCoefficients).toStrictEqual({
-      gold: 4.5,
-      silver: 3.2,
-      bronze: 1.9,
-    });
-    expect(nikeCoefficients.subjectNumericCoefficients).toHaveLength(1);
-    const nikeAccountAgeCoefficient = nikeCoefficients.subjectNumericCoefficients[0];
-    expect(nikeAccountAgeCoefficient.attributeKey).toBe('account_age');
-    expect(nikeAccountAgeCoefficient.coefficient).toBe(0.3);
-    expect(nikeAccountAgeCoefficient.missingValueCoefficient).toBe(0);
-    expect(nikeCoefficients.subjectCategoricalCoefficients).toHaveLength(1);
-    const nikeGenderIdentityCoefficient = nikeCoefficients.subjectCategoricalCoefficients[0];
-    expect(nikeGenderIdentityCoefficient.attributeKey).toBe('gender_identity');
-    expect(nikeGenderIdentityCoefficient.missingValueCoefficient).toBe(2.3);
-    expect(nikeGenderIdentityCoefficient.valueCoefficients).toStrictEqual({
-      female: 0.5,
-      male: -0.5,
+      const coldStartBandit = banditStore.get('cold_start_bandit');
+      expect(coldStartBandit?.banditKey).toBe('cold_start_bandit');
+      expect(coldStartBandit?.modelName).toBe('falcon');
+      expect(coldStartBandit?.modelVersion).toBe('cold start');
+      const coldStartModelData = coldStartBandit?.modelData;
+      expect(coldStartModelData?.gamma).toBe(1);
+      expect(coldStartModelData?.defaultActionScore).toBe(0);
+      expect(coldStartModelData?.actionProbabilityFloor).toBe(0);
+      expect(coldStartModelData?.coefficients).toStrictEqual({});
     });
 
-    // Just spot check the adidas parameters
-    expect(bannerCoefficients['adidas'].subjectNumericCoefficients).toHaveLength(0);
-    expect(
-      bannerCoefficients['adidas'].subjectCategoricalCoefficients[0].valueCoefficients['female'],
-    ).toBe(0);
-
-    const coldStartBandit = banditStore.get('cold_start_bandit');
-    expect(coldStartBandit?.banditKey).toBe('cold_start_bandit');
-    expect(coldStartBandit?.modelName).toBe('falcon');
-    expect(coldStartBandit?.modelVersion).toBe('cold start');
-    const coldStartModelData = coldStartBandit?.modelData;
-    expect(coldStartModelData?.gamma).toBe(1);
-    expect(coldStartModelData?.defaultActionScore).toBe(0);
-    expect(coldStartModelData?.actionProbabilityFloor).toBe(0);
-    expect(coldStartModelData?.coefficients).toStrictEqual({});
+    it('Will not fetch bandit parameters if there is no store', async () => {
+      configurationRequestor = new ConfigurationRequestor(httpClient, flagStore, undefined);
+      await configurationRequestor.fetchAndStoreConfigurations();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/configuration-requestor.ts
+++ b/src/configuration-requestor.ts
@@ -17,7 +17,9 @@ export default class ConfigurationRequestor {
     }
 
     await this.flagConfigurationStore.setEntries(configResponse.flags);
-    if (Object.keys(configResponse.bandits ?? {}).length) {
+    const flagsHaveBandits = Object.keys(configResponse.bandits ?? {}).length > 0;
+    const banditStoreProvided = !!this.banditConfigurationStore;
+    if (flagsHaveBandits && banditStoreProvided) {
       // TODO: different polling intervals for bandit parameters
       const banditResponse = await this.httpClient.getBanditParameters();
       if (banditResponse?.bandits) {

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1,12 +1,12 @@
 import { Flag, Shard, Range, Variation } from './interfaces';
 import { Rule, matchesRule } from './rules';
 import { MD5Sharder, Sharder } from './sharders';
-import { SubjectAttributes } from './types';
+import { Attributes } from './types';
 
 export interface FlagEvaluation {
   flagKey: string;
   subjectKey: string;
-  subjectAttributes: SubjectAttributes;
+  subjectAttributes: Attributes;
   allocationKey: string | null;
   variation: Variation | null;
   extraLogging: Record<string, string>;
@@ -23,7 +23,7 @@ export class Evaluator {
   evaluateFlag(
     flag: Flag,
     subjectKey: string,
-    subjectAttributes: SubjectAttributes,
+    subjectAttributes: Attributes,
     obfuscated: boolean,
   ): FlagEvaluation {
     if (!flag.enabled) {
@@ -76,7 +76,7 @@ export function hashKey(salt: string, subjectKey: string): string {
 export function noneResult(
   flagKey: string,
   subjectKey: string,
-  subjectAttributes: SubjectAttributes,
+  subjectAttributes: Attributes,
 ): FlagEvaluation {
   return {
     flagKey,
@@ -91,7 +91,7 @@ export function noneResult(
 
 export function matchesRules(
   rules: Rule[],
-  subjectAttributes: SubjectAttributes,
+  subjectAttributes: Attributes,
   obfuscated: boolean,
 ): boolean {
   return !rules.length || rules.some((rule) => matchesRule(rule, subjectAttributes, obfuscated));

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -63,8 +63,8 @@ export default class FetchHttpClient implements IHttpClient {
       // Clear timeout when response is received within the budget.
       clearTimeout(timeoutId);
 
-      if (!response.ok) {
-        throw new HttpRequestError('Failed to fetch data', response.status);
+      if (!response?.ok) {
+        throw new HttpRequestError('Failed to fetch data', response?.status);
       }
       return await response.json();
     } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import { MemoryStore, MemoryOnlyConfigurationStore } from './configuration-store
 import * as constants from './constants';
 import HttpClient from './http-client';
 import { Flag, VariationType } from './interfaces';
-import { AttributeType, SubjectAttributes } from './types';
+import { AttributeType, Attributes } from './types';
 import * as validation from './validation';
 
 export {
@@ -53,5 +53,5 @@ export {
   Flag,
   VariationType,
   AttributeType,
-  SubjectAttributes,
+  Attributes,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
 export type ValueType = string | number | boolean | JSON;
 export type AttributeType = string | number | boolean;
 export type ConditionValueType = AttributeType | AttributeType[];
-export type SubjectAttributes = { [key: string]: AttributeType };
+export type Attributes = { [key: string]: AttributeType };


### PR DESCRIPTION
_Eppo Internal:_
🎟️ **Ticket:** [FF-2407 - JS SDK - Bandit evaluator weigh actions](https://linear.app/eppo/issue/FF-2407/js-sdk-bandit-evaluator)
🗺️ **Design Review:** [Bandits Engineering Design](https://www.notion.so/eppo/Bandits-Engineering-Design-c5df5b6072b446aa8cacbf54e4d1f9df?pvs=4)(Relevant section: [Action Selection](https://www.notion.so/eppo/Bandits-Engineering-Design-c5df5b6072b446aa8cacbf54e4d1f9df?pvs=4#1ccc9845e4af42f78ad5ff08f304d402))

# Description
This pull request layers in the logic and tests for scoring and weighing bandit actions based on the context. The context compromises numeric and categorical attributes belonging to the subject being assigned and the action being considered.

After this pull request, future changes include:
- Deterministic shuffling and selection of an action
- Supporting passing action attributes in a way that explicitly delineates the numeric and categorical attributes