### PR TITLE
feat: [allow SDK to switch between obfuscation modes] (FF-2455)

### DIFF
--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -172,7 +172,7 @@ export default class EppoClient implements IEppoClient {
   constructor(
     private configurationStore: IConfigurationStore<Flag | ObfuscatedFlag>,
     private configurationRequestParameters?: FlagConfigurationRequestParameters,
-    private readonly isObfuscated = false,
+    private isObfuscated = false,
   ) {}
 
   public setConfigurationRequestParameters(
@@ -183,6 +183,10 @@ export default class EppoClient implements IEppoClient {
 
   public setConfigurationStore(configurationStore: IConfigurationStore<Flag | ObfuscatedFlag>) {
     this.configurationStore = configurationStore;
+  }
+
+  public setIsObfuscated(isObfuscated: boolean) {
+    this.isObfuscated = isObfuscated;
   }
 
   public async fetchFlagConfigurations() {


### PR DESCRIPTION
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

We need to enable customers to export configuration from their servers (with not obfuscated configuration) and bootstrap their clients (which default to obfuscated mode).

## Description
[//]: # (Describe your changes in detail)

Allows the client to be instantiated in the desired obfuscation mode.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

## For reviewers

I noticed `false` is the default - I'm not sure a default is desirable at all. The upstream clients should provide the default?

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
