### PR TITLE
feat: [export ObfuscatedFlag] (FF-2456)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import { MemoryStore, MemoryOnlyConfigurationStore } from './configuration-store
 import * as constants from './constants';
 import FlagConfigRequestor from './flag-configuration-requestor';
 import HttpClient from './http-client';
-import { Flag, VariationType } from './interfaces';
+import { Flag, ObfuscatedFlag, VariationType } from './interfaces';
 import { AttributeType, SubjectAttributes } from './types';
 import * as validation from './validation';
 
@@ -63,6 +63,7 @@ export {
   // Interfaces
   FlagConfigurationRequestParameters,
   Flag,
+  ObfuscatedFlag,
   VariationType,
   AttributeType,
   SubjectAttributes,


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

To support a customer request where they will be downloading the configuration outside of the JS SDK in obfuscated mode but need to bootstrap the JS SDK during sync initialization.

The configuration for this new method will be:

```
export interface IClientConfigSync {
  flagsConfiguration: Record<string, Flag | ObfuscatedFlag>;

  assignmentLogger?: IAssignmentLogger;

  isObfuscated?: boolean;

  throwOnFailedInitialization?: boolean;
}
```

We need to have the `ObfuscatedFlag` type available in the JS SDK.

## Description
[//]: # (Describe your changes in detail)

Exports `ObfuscatedFlag`.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
