### PR TITLE
Bandit selects and assigns action from weighted actions

### DIFF
--- a/src/bandit-evaluator.spec.ts
+++ b/src/bandit-evaluator.spec.ts
@@ -312,7 +312,6 @@ describe('BanditEvaluator', () => {
       expect(exposedEvaluator.selectAction(flagKey, 'subjectB', actionWeights)).toBe('action2');
       expect(exposedEvaluator.selectAction(flagKey, 'subjectV', actionWeights)).toBe('action3');
 
-      /*
       const assignmentCounts: Record<string, number> = { action1: 0, action2: 0, action3: 0 };
       for (let i = 0; i < 100000; i += 1) {
         const subjectKey = `subject${i}`;
@@ -320,7 +319,6 @@ describe('BanditEvaluator', () => {
         assignmentCounts[assignment] += 1;
       }
       console.log('>>>>>>', assignmentCounts); // { action1: 33526, action2: 53152, action3: 13322 }
-       */
     });
   });
 

--- a/src/bandit-evaluator.spec.ts
+++ b/src/bandit-evaluator.spec.ts
@@ -29,6 +29,11 @@ describe('BanditEvaluator', () => {
       gamma: number,
       actionProbabilityFloor: number,
     ) => Record<string, number>;
+    selectAction: (
+      flagKey: string,
+      subjectKey: string,
+      actionWeights: Record<string, number>,
+    ) => string;
   };
 
   describe('scoreNumericAttributes', () => {
@@ -295,6 +300,27 @@ describe('BanditEvaluator', () => {
         // Since we know the floor will be in effect, we use > 0.09999 instead of >= 0.1 to account for lack of precision with floating point numbers
         Object.values(actionWeightsHighProbabilityFloor).every((weight) => weight > 0.099999),
       ).toBe(true);
+    });
+  });
+
+  describe('selectAction', () => {
+    const flagKey = 'flag';
+    const actionWeights = { action1: 0.4, action2: 0.6, action3: 0.2 };
+
+    it('selects actions', () => {
+      expect(exposedEvaluator.selectAction(flagKey, 'subjectA', actionWeights)).toBe('action1');
+      expect(exposedEvaluator.selectAction(flagKey, 'subjectB', actionWeights)).toBe('action2');
+      expect(exposedEvaluator.selectAction(flagKey, 'subjectV', actionWeights)).toBe('action3');
+
+      /*
+      const assignmentCounts: Record<string, number> = { action1: 0, action2: 0, action3: 0 };
+      for (let i = 0; i < 100000; i += 1) {
+        const subjectKey = `subject${i}`;
+        const assignment = exposedEvaluator.selectAction(flagKey, subjectKey, actionWeights);
+        assignmentCounts[assignment] += 1;
+      }
+      console.log('>>>>>>', assignmentCounts); // { action1: 33526, action2: 53152, action3: 13322 }
+       */
     });
   });
 });

--- a/src/bandit-evaluator.spec.ts
+++ b/src/bandit-evaluator.spec.ts
@@ -305,22 +305,12 @@ describe('BanditEvaluator', () => {
 
   describe('selectAction', () => {
     const flagKey = 'flag';
-    const actionWeights = { action1: 0.4, action2: 0.6, action3: 0.2 };
+    const actionWeights = { action1: 0.2, action2: 0.5, action3: 0.3 };
 
     it('selects actions', () => {
       expect(exposedEvaluator.selectAction(flagKey, 'subjectA', actionWeights)).toBe('action1');
       expect(exposedEvaluator.selectAction(flagKey, 'subjectB', actionWeights)).toBe('action2');
-      expect(exposedEvaluator.selectAction(flagKey, 'subjectV', actionWeights)).toBe('action3');
-
-      /*
-      const assignmentCounts: Record<string, number> = { action1: 0, action2: 0, action3: 0 };
-      for (let i = 0; i < 100000; i += 1) {
-        const subjectKey = Math.random().toString(36).substring(2);
-        const assignment = exposedEvaluator.selectAction(flagKey, subjectKey, actionWeights);
-        assignmentCounts[assignment] += 1;
-      }
-      console.log('>>>>>>', assignmentCounts); // { action1: 33526, action2: 53152, action3: 13322 }
-      */
+      expect(exposedEvaluator.selectAction(flagKey, 'subjectE', actionWeights)).toBe('action3');
     });
   });
 

--- a/src/bandit-evaluator.spec.ts
+++ b/src/bandit-evaluator.spec.ts
@@ -379,7 +379,7 @@ describe('BanditEvaluator', () => {
       expect(result.actionKey).toBe('action1');
       expect(result.actionAttributes).toStrictEqual(actions.action1);
       expect(result.actionScore).toBe(3.2);
-      expect(result.actionWeight).toBeCloseTo(0.41);
+      expect(result.actionWeight).toBeCloseTo(0.417);
       expect(result.gamma).toBe(banditModel.gamma);
       expect(result.optimalityGap).toBe(0);
     });

--- a/src/bandit-evaluator.spec.ts
+++ b/src/bandit-evaluator.spec.ts
@@ -323,4 +323,65 @@ describe('BanditEvaluator', () => {
        */
     });
   });
+
+  describe('evaluateBandit', () => {
+    it('evaluates the bandit', () => {
+      const flagKey = 'test_flag';
+      const subjectKey = 'test_subject';
+      const subjectAttributes = { age: 25, location: 'US' };
+      const actions: Record<string, Attributes> = {
+        action1: { price: 10, category: 'A' },
+        action2: { price: 20, category: 'B' },
+      };
+      const banditModel: BanditModelData = {
+        gamma: 0.1,
+        defaultActionScore: 0.0,
+        actionProbabilityFloor: 0.1,
+        coefficients: {
+          action1: {
+            actionKey: 'action1',
+            intercept: 0.5,
+            subjectNumericCoefficients: [
+              { attributeKey: 'age', coefficient: 0.1, missingValueCoefficient: 0.0 },
+            ],
+            subjectCategoricalCoefficients: [
+              {
+                attributeKey: 'location',
+                missingValueCoefficient: 0.0,
+                valueCoefficients: { US: 0.2 },
+              },
+            ],
+            actionNumericCoefficients: [
+              { attributeKey: 'price', coefficient: 0.05, missingValueCoefficient: 0.0 },
+            ],
+            actionCategoricalCoefficients: [
+              {
+                attributeKey: 'category',
+                missingValueCoefficient: 0.0,
+                valueCoefficients: { A: 0.3 },
+              },
+            ],
+          },
+        },
+      };
+
+      const result = banditEvaluator.evaluateBandit(
+        flagKey,
+        subjectKey,
+        subjectAttributes,
+        actions,
+        banditModel,
+      );
+
+      expect(result.flagKey).toBe(flagKey);
+      expect(result.subjectKey).toBe(subjectKey);
+      expect(result.subjectAttributes).toStrictEqual(subjectAttributes);
+      expect(result.actionKey).toBe('action1');
+      expect(result.actionAttributes).toStrictEqual(actions.action1);
+      expect(result.actionScore).toBe(3.2);
+      expect(result.actionWeight).toBeCloseTo(0.41);
+      expect(result.gamma).toBe(banditModel.gamma);
+      expect(result.optimalityGap).toBe(0);
+    });
+  });
 });

--- a/src/bandit-evaluator.ts
+++ b/src/bandit-evaluator.ts
@@ -49,8 +49,6 @@ export class BanditEvaluator {
     );
     const optimalityGap = topScore - actionScores[selectedActionKey];
 
-    console.log('>>>>>>>', { actionScores, actionWeights, selectedActionKey, optimalityGap });
-
     return {
       flagKey,
       subjectKey,

--- a/src/bandit-evaluator.ts
+++ b/src/bandit-evaluator.ts
@@ -190,9 +190,10 @@ export class BanditEvaluator {
         `${flagKey}-${subjectKey}-${b[0]}`,
         this.assignmentShards,
       );
+      console.log('>> SORTING >> ', { [a[0]]: actionAShard, [b[0]]: actionBShard });
       let result = actionAShard - actionBShard;
       if (result === 0) {
-        // Break the unlikely case of a tie in randomized assigned shards by action name
+        // In the unlikely case of a tie in randomized assigned shards, break the tie with the action names
         result = a[0] < b[0] ? -1 : 1;
       }
       return result;
@@ -201,11 +202,12 @@ export class BanditEvaluator {
     // Select action from the shuffled actions, based on weight
     const assignedShard = this.sharder.getShard(`${flagKey}-${subjectKey}`, this.assignmentShards);
     const assignmentWeightThreshold = assignedShard / this.assignmentShards;
+    console.log({ assignedShard, assignmentWeightThreshold, shuffledActions });
     let cumulativeWeight = 0;
     let assignedAction: string | null = null;
     for (const actionWeight of shuffledActions) {
       cumulativeWeight += actionWeight[1];
-      if (cumulativeWeight > assignmentWeightThreshold) {
+      if (cumulativeWeight > assignmentWeightThreshold) { // TODO: should this be >= ?
         assignedAction = actionWeight[0];
         break;
       }

--- a/src/bandit-evaluator.ts
+++ b/src/bandit-evaluator.ts
@@ -41,7 +41,15 @@ export class BanditEvaluator {
       banditModel.actionProbabilityFloor,
     );
     const selectedActionKey: string = this.selectAction(flagKey, subjectKey, actionWeights);
-    const optimalityGap = 0; // TODO: compute difference between selected and max
+
+    // Compute optimality gap in terms of score
+    const topScore = Object.values(actionScores).reduce(
+      (maxScore, score) => (score > maxScore ? score : maxScore),
+      -Infinity,
+    );
+    const optimalityGap = topScore - actionScores[selectedActionKey];
+
+    console.log('>>>>>>>', { actionScores, actionWeights, selectedActionKey, optimalityGap });
 
     return {
       flagKey,
@@ -190,7 +198,6 @@ export class BanditEvaluator {
         `${flagKey}-${subjectKey}-${b[0]}`,
         this.assignmentShards,
       );
-      //console.log('>> SORTING >> ', { [a[0]]: actionAShard, [b[0]]: actionBShard });
       let result = actionAShard - actionBShard;
       if (result === 0) {
         // In the unlikely case of a tie in randomized assigned shards, break the tie with the action names
@@ -202,7 +209,6 @@ export class BanditEvaluator {
     // Select action from the shuffled actions, based on weight
     const assignedShard = this.sharder.getShard(`${flagKey}-${subjectKey}`, this.assignmentShards);
     const assignmentWeightThreshold = assignedShard / this.assignmentShards;
-    //console.log('>>>>>>', { assignedShard, assignmentWeightThreshold, shuffledActions });
     let cumulativeWeight = 0;
     let assignedAction: string | null = null;
     for (const actionWeight of shuffledActions) {

--- a/src/bandit-evaluator.ts
+++ b/src/bandit-evaluator.ts
@@ -190,7 +190,7 @@ export class BanditEvaluator {
         `${flagKey}-${subjectKey}-${b[0]}`,
         this.assignmentShards,
       );
-      console.log('>> SORTING >> ', { [a[0]]: actionAShard, [b[0]]: actionBShard });
+      //console.log('>> SORTING >> ', { [a[0]]: actionAShard, [b[0]]: actionBShard });
       let result = actionAShard - actionBShard;
       if (result === 0) {
         // In the unlikely case of a tie in randomized assigned shards, break the tie with the action names
@@ -202,7 +202,7 @@ export class BanditEvaluator {
     // Select action from the shuffled actions, based on weight
     const assignedShard = this.sharder.getShard(`${flagKey}-${subjectKey}`, this.assignmentShards);
     const assignmentWeightThreshold = assignedShard / this.assignmentShards;
-    console.log({ assignedShard, assignmentWeightThreshold, shuffledActions });
+    //console.log('>>>>>>', { assignedShard, assignmentWeightThreshold, shuffledActions });
     let cumulativeWeight = 0;
     let assignedAction: string | null = null;
     for (const actionWeight of shuffledActions) {

--- a/src/bandit-evaluator.ts
+++ b/src/bandit-evaluator.ts
@@ -4,8 +4,8 @@ import {
   BanditModelData,
   BanditNumericAttributeCoefficients,
 } from './interfaces';
-import { Attributes } from './types';
 import { MD5Sharder, Sharder } from './sharders';
+import { Attributes } from './types';
 
 export interface BanditEvaluation {
   flagKey: string;

--- a/src/bandit-evaluator.ts
+++ b/src/bandit-evaluator.ts
@@ -40,7 +40,6 @@ export class BanditEvaluator {
       banditModel.gamma,
       banditModel.actionProbabilityFloor,
     );
-    console.log('>>>>>', { actionScores, actionWeights });
     const selectedActionKey: string = this.selectAction(flagKey, subjectKey, actionWeights);
 
     // Compute optimality gap in terms of score

--- a/src/bandit-evaluator.ts
+++ b/src/bandit-evaluator.ts
@@ -40,6 +40,7 @@ export class BanditEvaluator {
       banditModel.gamma,
       banditModel.actionProbabilityFloor,
     );
+    console.log('>>>>>', { actionScores, actionWeights });
     const selectedActionKey: string = this.selectAction(flagKey, subjectKey, actionWeights);
 
     // Compute optimality gap in terms of score

--- a/src/bandit-evaluator.ts
+++ b/src/bandit-evaluator.ts
@@ -211,7 +211,7 @@ export class BanditEvaluator {
     let assignedAction: string | null = null;
     for (const actionWeight of shuffledActions) {
       cumulativeWeight += actionWeight[1];
-      if (cumulativeWeight > assignmentWeightThreshold) { // TODO: should this be >= ?
+      if (cumulativeWeight > assignmentWeightThreshold) {
         assignedAction = actionWeight[0];
         break;
       }

--- a/src/bandit-logger.ts
+++ b/src/bandit-logger.ts
@@ -16,15 +16,6 @@ export interface IBanditEvent {
   metaData?: Record<string, unknown>;
 }
 
-/**
- * Implement this interface log variation assignments to your data warehouse.
- * @public
- */
 export interface IBanditLogger {
-  /**
-   * Invoked when a subject is assigned to an experiment variation.
-   * @param assignment holds the variation an experiment subject was assigned to
-   * @public
-   */
   logBanditAction(assignment: IBanditEvent): void;
 }

--- a/src/bandit-logger.ts
+++ b/src/bandit-logger.ts
@@ -1,0 +1,30 @@
+import { Attributes } from './types';
+
+export interface IBanditEvent {
+  timestamp: string;
+  featureFlag: string;
+  bandit: string;
+  subject: string;
+  action: string | null;
+  actionProbability: number | null;
+  optimalityGap: number | null;
+  modelVersion: string;
+  subjectNumericAttributes: Attributes;
+  subjectCategoricalAttributes: Attributes;
+  actionNumericAttributes: Attributes;
+  actionCategoricalAttributes: Attributes;
+  metaData?: Record<string, unknown>;
+}
+
+/**
+ * Implement this interface log variation assignments to your data warehouse.
+ * @public
+ */
+export interface IBanditLogger {
+  /**
+   * Invoked when a subject is assigned to an experiment variation.
+   * @param assignment holds the variation an experiment subject was assigned to
+   * @public
+   */
+  logBanditAction(assignment: IBanditEvent): void;
+}

--- a/src/client/eppo-client-with-bandits.spec.ts
+++ b/src/client/eppo-client-with-bandits.spec.ts
@@ -64,6 +64,7 @@ describe('EppoClient Bandits E2E test', () => {
       'Shared bandit test data - %s',
       async (flagKey: string) => {
         const { defaultValue, subjects } = testsByFlagKey[flagKey];
+        let numAssignmentsChecked = 0;
         subjects.forEach((subject) => {
           // TODO: handle already-bucketed attributes
           // TODO: common test case with a numeric value passed as a categorical attribute and vice verse
@@ -102,7 +103,10 @@ describe('EppoClient Bandits E2E test', () => {
 
           expect(banditAssignment.variation).toBe(subject.assignment.variation);
           expect(banditAssignment.action).toBe(subject.assignment.action);
+          numAssignmentsChecked += 1;
         });
+        // Ensure that this test case correctly checked some test assignments
+        expect(numAssignmentsChecked).toBeGreaterThan(0);
       },
     );
   });

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -9,7 +9,7 @@ import {
   getTestAssignments,
   readAssignmentTestData,
   readMockUFCResponse,
-  validateTestAssignments, ASSIGNMENT_TEST_DATA_DIR,
+  validateTestAssignments,
 } from '../../test/testHelpers';
 import ApiEndpoints from '../api-endpoints';
 import { IAssignmentLogger } from '../assignment-logger';
@@ -150,7 +150,7 @@ describe('EppoClient E2E test', () => {
 
       const client = new EppoClient(storage);
       client.getStringAssignment(flagKey, 'subject-to-be-logged', {}, 'default-value');
-      client.setLogger(mockLogger);
+      client.setAssignmentLogger(mockLogger);
 
       expect(td.explain(mockLogger.logAssignment).callCount).toEqual(1);
       expect(td.explain(mockLogger.logAssignment).calls[0].args[0].subject).toEqual(
@@ -164,9 +164,9 @@ describe('EppoClient E2E test', () => {
       const client = new EppoClient(storage);
 
       client.getStringAssignment(flagKey, 'subject-to-be-logged', {}, 'default-value');
-      client.setLogger(mockLogger);
+      client.setAssignmentLogger(mockLogger);
       expect(td.explain(mockLogger.logAssignment).callCount).toEqual(1);
-      client.setLogger(mockLogger);
+      client.setAssignmentLogger(mockLogger);
       expect(td.explain(mockLogger.logAssignment).callCount).toEqual(1);
     });
 
@@ -177,7 +177,7 @@ describe('EppoClient E2E test', () => {
       times(MAX_EVENT_QUEUE_SIZE + 100, (i) =>
         client.getStringAssignment(flagKey, `subject-to-be-logged-${i}`, {}, 'default-value'),
       );
-      client.setLogger(mockLogger);
+      client.setAssignmentLogger(mockLogger);
       expect(td.explain(mockLogger.logAssignment).callCount).toEqual(MAX_EVENT_QUEUE_SIZE);
     });
   });
@@ -312,7 +312,7 @@ describe('EppoClient E2E test', () => {
 
     storage.setEntries({ [flagKey]: mockFlag });
     const client = new EppoClient(storage);
-    client.setLogger(mockLogger);
+    client.setAssignmentLogger(mockLogger);
 
     const subjectAttributes = { foo: 3 };
     const assignment = client.getStringAssignment(
@@ -338,7 +338,7 @@ describe('EppoClient E2E test', () => {
 
     storage.setEntries({ [flagKey]: mockFlag });
     const client = new EppoClient(storage);
-    client.setLogger(mockLogger);
+    client.setAssignmentLogger(mockLogger);
 
     const subjectAttributes = { foo: 3 };
     const assignment = client.getStringAssignment(
@@ -360,7 +360,7 @@ describe('EppoClient E2E test', () => {
 
       storage.setEntries({ [flagKey]: mockFlag });
       client = new EppoClient(storage);
-      client.setLogger(mockLogger);
+      client.setAssignmentLogger(mockLogger);
     });
 
     it('logs duplicate assignments without an assignment cache', async () => {
@@ -402,7 +402,7 @@ describe('EppoClient E2E test', () => {
         new Error('logging error'),
       );
 
-      client.setLogger(mockLogger);
+      client.setAssignmentLogger(mockLogger);
 
       client.getStringAssignment(flagKey, 'subject-10', {}, 'default');
       client.getStringAssignment(flagKey, 'subject-10', {}, 'default');

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -9,7 +9,7 @@ import {
   getTestAssignments,
   readAssignmentTestData,
   readMockUFCResponse,
-  validateTestAssignments,
+  validateTestAssignments, ASSIGNMENT_TEST_DATA_DIR,
 } from '../../test/testHelpers';
 import ApiEndpoints from '../api-endpoints';
 import { IAssignmentLogger } from '../assignment-logger';

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -7,9 +7,10 @@ import {
   OBFUSCATED_MOCK_UFC_RESPONSE_FILE,
   SubjectTestCase,
   getTestAssignments,
-  readAssignmentTestData,
   readMockUFCResponse,
   validateTestAssignments,
+  readTestData,
+  ASSIGNMENT_TEST_DATA_DIR,
 } from '../../test/testHelpers';
 import ApiEndpoints from '../api-endpoints';
 import { IAssignmentLogger } from '../assignment-logger';
@@ -205,7 +206,7 @@ describe('EppoClient E2E test', () => {
       jest.restoreAllMocks();
     });
 
-    it.each(readAssignmentTestData())(
+    it.each(readTestData<IAssignmentTestCase>(ASSIGNMENT_TEST_DATA_DIR))(
       'test variation assignment splits',
       async ({ flag, variationType, defaultValue, subjects }: IAssignmentTestCase) => {
         const client = new EppoClient(storage);
@@ -256,7 +257,7 @@ describe('EppoClient E2E test', () => {
       jest.restoreAllMocks();
     });
 
-    it.each(readAssignmentTestData())(
+    it.each(readTestData<IAssignmentTestCase>(ASSIGNMENT_TEST_DATA_DIR))(
       'test variation assignment splits',
       async ({ flag, variationType, defaultValue, subjects }: IAssignmentTestCase) => {
         const client = new EppoClient(storage, undefined, undefined, true);

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -362,7 +362,7 @@ export default class EppoClient implements IEppoClient {
     flagKey: string,
     subjectKey: string,
     subjectAttributes: Attributes,
-    actions: Record<string, Attributes>,
+    actions: Record<string, Attributes>, // TODO: ability to provide a set of actions with no context, or context broken out by numeric/categorical
     defaultValue: string,
   ): { variation: string; action: string | null } {
     let variation = this.getStringAssignment(flagKey, subjectKey, subjectAttributes, defaultValue);

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -370,7 +370,7 @@ export default class EppoClient implements IEppoClient {
     const banditKey = variation;
     try {
       const banditParameters = this.banditConfigurationStore?.get(banditKey);
-      if (banditParameters && !actions?.length) {
+      if (banditParameters && !Object.keys(actions ?? {}).length) {
         // If it's a bandit, but we have no actions, just return default value
         variation = defaultValue;
       } else if (banditParameters) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,3 +9,4 @@ export const SESSION_ASSIGNMENT_CONFIG_LOADED = 'eppo-session-assignment-config-
 export const NULL_SENTINEL = 'EPPO_NULL';
 // number of logging events that may be queued while waiting for initialization
 export const MAX_EVENT_QUEUE_SIZE = 100;
+export const BANDIT_ASSIGNMENT_SHARDS = 10000;

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -1,10 +1,11 @@
 import * as fs from 'fs';
 
-import { VariationType, AttributeType } from '../src';
+import { VariationType, AttributeType, Attributes } from '../src';
 import { IBanditParametersResponse, IUniversalFlagConfigResponse } from '../src/http-client';
 
 export const TEST_DATA_DIR = './test/data/ufc/';
 export const ASSIGNMENT_TEST_DATA_DIR = TEST_DATA_DIR + 'tests/';
+export const BANDIT_TEST_DATA_DIR = TEST_DATA_DIR + 'bandit-tests/';
 const MOCK_UFC_FILENAME = 'flags-v1';
 export const MOCK_UFC_RESPONSE_FILE = `${MOCK_UFC_FILENAME}.json`;
 export const MOCK_FLAGS_WITH_BANDITS_RESPONSE_FILE = `bandit-flags-v1.json`;
@@ -23,6 +24,25 @@ export interface IAssignmentTestCase {
   subjects: SubjectTestCase[];
 }
 
+export interface BanditTestCase {
+  flag: string;
+  defaultValue: string;
+  subjects: BanditTestCaseSubject[];
+}
+
+interface BanditTestCaseSubject {
+  subjectKey: string;
+  subjectAttributes: { numeric_attributes: Attributes; categorical_attributes: Attributes };
+  actions: BanditTestCaseAction[];
+  assignment: { variation: string; action: string | null };
+}
+
+interface BanditTestCaseAction {
+  actionKey: string;
+  numericAttributes: Attributes;
+  categoricalAttributes: Attributes;
+}
+
 export function readMockUFCResponse(
   filename: string,
 ): IUniversalFlagConfigResponse | IBanditParametersResponse {
@@ -33,6 +53,17 @@ export function readAssignmentTestData(): IAssignmentTestCase[] {
   return fs
     .readdirSync(ASSIGNMENT_TEST_DATA_DIR)
     .map((file) => JSON.parse(fs.readFileSync(ASSIGNMENT_TEST_DATA_DIR + file, 'utf8')));
+}
+
+// TODO: consolidate duplicate code with above
+export function readBanditTestData(): BanditTestCase[] {
+  const testCases = fs
+    .readdirSync(BANDIT_TEST_DATA_DIR)
+    .map((file) => JSON.parse(fs.readFileSync(BANDIT_TEST_DATA_DIR + file, 'utf8')));
+  if (!testCases.length) {
+    throw new Error('No test cases at ' + BANDIT_TEST_DATA_DIR);
+  }
+  return testCases;
 }
 
 export function getTestAssignments(

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -49,19 +49,12 @@ export function readMockUFCResponse(
   return JSON.parse(fs.readFileSync(TEST_DATA_DIR + filename, 'utf-8'));
 }
 
-export function readAssignmentTestData(): IAssignmentTestCase[] {
-  return fs
-    .readdirSync(ASSIGNMENT_TEST_DATA_DIR)
-    .map((file) => JSON.parse(fs.readFileSync(ASSIGNMENT_TEST_DATA_DIR + file, 'utf8')));
-}
-
-// TODO: consolidate duplicate code with above
-export function readBanditTestData(): BanditTestCase[] {
+export function readTestData<T>(testDirectory: string): T[] {
   const testCases = fs
-    .readdirSync(BANDIT_TEST_DATA_DIR)
-    .map((file) => JSON.parse(fs.readFileSync(BANDIT_TEST_DATA_DIR + file, 'utf8')));
+    .readdirSync(testDirectory)
+    .map((file) => JSON.parse(fs.readFileSync(testDirectory + file, 'utf8')));
   if (!testCases.length) {
-    throw new Error('No test cases at ' + BANDIT_TEST_DATA_DIR);
+    throw new Error('No test cases at ' + testDirectory);
   }
   return testCases;
 }


### PR DESCRIPTION
After PRs #85 and #88, we fetch bandit parameters, use them to score actions, and then weigh the probabilities of those actions so they collectively add up to `1.0`.

This PR builds on that by shuffling and then selecting a weighted action to assign, as well as logging the result.

The [shared test cases pass](https://github.com/Eppo-exp/sdk-test-data/tree/main/ufc/bandit-tests), as well as some newly-added client-specific ones, such as making sure the right stuff is being passed to the logger.