### PR TITLE
FF-2465 Evaluation Reasons

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "eslint.format.enable": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -27,126 +27,6 @@ import { AttributeType, ValueType } from '../types';
 import { validateNotBlank } from '../validation';
 import { LIB_VERSION } from '../version';
 
-/**
- * Client for assigning experiment variations.
- * @public
- */
-export interface IEppoClient {
-  /**
-   * Maps a subject to a variation for a given experiment.
-   *
-   * @param flagKey feature flag identifier
-   * @param subjectKey an identifier of the experiment subject, for example a user ID.
-   * @param subjectAttributes optional attributes associated with the subject, for example name and email.
-   * @param defaultValue default value to return if the subject is not part of the experiment sample
-   * The subject attributes are used for evaluating any targeting rules tied to the experiment.
-   * @returns a variation value if the subject is part of the experiment sample, otherwise the default value
-   * @public
-   */
-  getStringAssignment(
-    flagKey: string,
-    subjectKey: string,
-    subjectAttributes: Record<string, AttributeType>,
-    defaultValue: string,
-  ): string;
-
-  /**
-   * @deprecated use getBooleanAssignment instead.
-   */
-  getBoolAssignment(
-    flagKey: string,
-    subjectKey: string,
-    subjectAttributes: Record<string, AttributeType>,
-    defaultValue: boolean,
-  ): boolean;
-
-  /**
-   * Maps a subject to a boolean variation for a given experiment.
-   *
-   * @param flagKey feature flag identifier
-   * @param subjectKey an identifier of the experiment subject, for example a user ID.
-   * @param subjectAttributes optional attributes associated with the subject, for example name and email.
-   * @param defaultValue default value to return if the subject is not part of the experiment sample
-   * @returns a boolean variation value if the subject is part of the experiment sample, otherwise the default value
-   */
-  getBooleanAssignment(
-    flagKey: string,
-    subjectKey: string,
-    subjectAttributes: Record<string, AttributeType>,
-    defaultValue: boolean,
-  ): boolean;
-
-  /**
-   * Maps a subject to an Integer variation for a given experiment.
-   *
-   * @param flagKey feature flag identifier
-   * @param subjectKey an identifier of the experiment subject, for example a user ID.
-   * @param subjectAttributes optional attributes associated with the subject, for example name and email.
-   * @param defaultValue default value to return if the subject is not part of the experiment sample
-   * @returns a number variation value if the subject is part of the experiment sample, otherwise the default value
-   */
-  getIntegerAssignment(
-    flagKey: string,
-    subjectKey: string,
-    subjectAttributes: Record<string, AttributeType>,
-    defaultValue: number,
-  ): number;
-
-  /**
-   * Maps a subject to a Numeric variation for a given experiment.
-   *
-   * @param flagKey feature flag identifier
-   * @param subjectKey an identifier of the experiment subject, for example a user ID.
-   * @param subjectAttributes optional attributes associated with the subject, for example name and email.
-   * @param defaultValue default value to return if the subject is not part of the experiment sample
-   * @returns a number variation value if the subject is part of the experiment sample, otherwise the default value
-   */
-  getNumericAssignment(
-    flagKey: string,
-    subjectKey: string,
-    subjectAttributes: Record<string, AttributeType>,
-    defaultValue: number,
-  ): number;
-
-  /**
-   * Maps a subject to a JSON variation for a given experiment.
-   *
-   * @param flagKey feature flag identifier
-   * @param subjectKey an identifier of the experiment subject, for example a user ID.
-   * @param subjectAttributes optional attributes associated with the subject, for example name and email.
-   * @param defaultValue default value to return if the subject is not part of the experiment sample
-   * @returns a JSON object variation value if the subject is part of the experiment sample, otherwise the default value
-   */
-  getJSONAssignment(
-    flagKey: string,
-    subjectKey: string,
-    subjectAttributes: Record<string, AttributeType>,
-    defaultValue: object,
-  ): object;
-
-  setLogger(logger: IAssignmentLogger): void;
-
-  useLRUInMemoryAssignmentCache(maxSize: number): void;
-
-  useCustomAssignmentCache(cache: AssignmentCache): void;
-
-  setConfigurationRequestParameters(
-    configurationRequestParameters: FlagConfigurationRequestParameters,
-  ): void;
-
-  setConfigurationStore(configurationStore: IConfigurationStore<Flag | ObfuscatedFlag>): void;
-
-  fetchFlagConfigurations(): void;
-
-  stopPolling(): void;
-
-  setIsGracefulFailureMode(gracefulFailureMode: boolean): void;
-
-  getFlagKeys(): string[];
-
-  isInitialized(): boolean;
-}
-
 export type FlagConfigurationRequestParameters = {
   apiKey: string;
   sdkVersion: string;
@@ -161,7 +41,7 @@ export type FlagConfigurationRequestParameters = {
   skipInitialPoll?: boolean;
 };
 
-export default class EppoClient implements IEppoClient {
+export default class EppoClient {
   private queuedEvents: IAssignmentEvent[] = [];
   private assignmentLogger?: IAssignmentLogger;
   private isGracefulFailureMode = true;
@@ -247,6 +127,17 @@ export default class EppoClient implements IEppoClient {
     }
   }
 
+  /**
+   * Maps a subject to a variation for a given experiment.
+   *
+   * @param flagKey feature flag identifier
+   * @param subjectKey an identifier of the experiment subject, for example a user ID.
+   * @param subjectAttributes optional attributes associated with the subject, for example name and email.
+   * @param defaultValue default value to return if the subject is not part of the experiment sample
+   * The subject attributes are used for evaluating any targeting rules tied to the experiment.
+   * @returns a variation value if the subject is part of the experiment sample, otherwise the default value
+   * @public
+   */
   public getStringAssignment(
     flagKey: string,
     subjectKey: string,
@@ -264,6 +155,9 @@ export default class EppoClient implements IEppoClient {
     );
   }
 
+  /**
+   * @deprecated use getBooleanAssignment instead.
+   */
   public getBoolAssignment(
     flagKey: string,
     subjectKey: string,
@@ -273,6 +167,15 @@ export default class EppoClient implements IEppoClient {
     return this.getBooleanAssignment(flagKey, subjectKey, subjectAttributes, defaultValue);
   }
 
+  /**
+   * Maps a subject to a boolean variation for a given experiment.
+   *
+   * @param flagKey feature flag identifier
+   * @param subjectKey an identifier of the experiment subject, for example a user ID.
+   * @param subjectAttributes optional attributes associated with the subject, for example name and email.
+   * @param defaultValue default value to return if the subject is not part of the experiment sample
+   * @returns a boolean variation value if the subject is part of the experiment sample, otherwise the default value
+   */
   public getBooleanAssignment(
     flagKey: string,
     subjectKey: string,
@@ -290,6 +193,15 @@ export default class EppoClient implements IEppoClient {
     );
   }
 
+  /**
+   * Maps a subject to an Integer variation for a given experiment.
+   *
+   * @param flagKey feature flag identifier
+   * @param subjectKey an identifier of the experiment subject, for example a user ID.
+   * @param subjectAttributes optional attributes associated with the subject, for example name and email.
+   * @param defaultValue default value to return if the subject is not part of the experiment sample
+   * @returns a number variation value if the subject is part of the experiment sample, otherwise the default value
+   */
   public getIntegerAssignment(
     flagKey: string,
     subjectKey: string,
@@ -307,6 +219,15 @@ export default class EppoClient implements IEppoClient {
     );
   }
 
+  /**
+   * Maps a subject to a Numeric variation for a given experiment.
+   *
+   * @param flagKey feature flag identifier
+   * @param subjectKey an identifier of the experiment subject, for example a user ID.
+   * @param subjectAttributes optional attributes associated with the subject, for example name and email.
+   * @param defaultValue default value to return if the subject is not part of the experiment sample
+   * @returns a number variation value if the subject is part of the experiment sample, otherwise the default value
+   */
   public getNumericAssignment(
     flagKey: string,
     subjectKey: string,
@@ -324,6 +245,15 @@ export default class EppoClient implements IEppoClient {
     );
   }
 
+  /**
+   * Maps a subject to a JSON variation for a given experiment.
+   *
+   * @param flagKey feature flag identifier
+   * @param subjectKey an identifier of the experiment subject, for example a user ID.
+   * @param subjectAttributes optional attributes associated with the subject, for example name and email.
+   * @param defaultValue default value to return if the subject is not part of the experiment sample
+   * @returns a JSON object variation value if the subject is part of the experiment sample, otherwise the default value
+   */
   public getJSONAssignment(
     flagKey: string,
     subjectKey: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {
   assignmentCacheKeyToString,
   assignmentCacheValueToString,
 } from './cache/abstract-assignment-cache';
-import EppoClient, { FlagConfigurationRequestParameters, IEppoClient } from './client/eppo-client';
+import EppoClient, { FlagConfigurationRequestParameters } from './client/eppo-client';
 import {
   IConfigurationStore,
   IAsyncStore,
@@ -35,7 +35,6 @@ export {
   IAssignmentLogger,
   IAssignmentEvent,
   EppoClient,
-  IEppoClient,
   constants,
   FlagConfigRequestor,
   HttpClient,


### PR DESCRIPTION
This is the first part of the "Evaluation Reasons" work. This PR entail removal of IEppoClient to make it easier to add functions to EppoClient. `IEppoClient` was an unnecessary interface (discussion: https://eppo-group.slack.com/archives/C04KR1GGE3C/p1718890880706789)
