### PR TITLE
feat: [export api endpoints class] (ff 2310)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/api-endpoint.spec.ts
+++ b/src/api-endpoint.spec.ts
@@ -1,4 +1,5 @@
 import ApiEndpoints from './api-endpoints';
+import { BASE_URL as DEFAULT_BASE_URL } from './constants';
 
 describe('ApiEndpoints', () => {
   it('should append query parameters to the URL', () => {
@@ -12,6 +13,20 @@ describe('ApiEndpoints', () => {
     );
     expect(apiEndpoints.ufcEndpoint().toString()).toEqual(
       'http://api.example.com/flag-config/v1/config?apiKey=12345&sdkVersion=foobar&sdkName=ExampleSDK',
+    );
+  });
+
+  it('should use default base URL if not provided', () => {
+    const apiEndpoints = new ApiEndpoints(undefined, {
+      apiKey: '12345',
+      sdkVersion: 'foobar',
+      sdkName: 'ExampleSDK',
+    });
+    expect(apiEndpoints.endpoint('/data').toString()).toEqual(
+      `${DEFAULT_BASE_URL}/data?apiKey=12345&sdkVersion=foobar&sdkName=ExampleSDK`,
+    );
+    expect(apiEndpoints.ufcEndpoint().toString()).toEqual(
+      `${DEFAULT_BASE_URL}/flag-config/v1/config?apiKey=12345&sdkVersion=foobar&sdkName=ExampleSDK`,
     );
   });
 });

--- a/src/api-endpoint.spec.ts
+++ b/src/api-endpoint.spec.ts
@@ -3,10 +3,13 @@ import { BASE_URL as DEFAULT_BASE_URL } from './constants';
 
 describe('ApiEndpoints', () => {
   it('should append query parameters to the URL', () => {
-    const apiEndpoints = new ApiEndpoints('http://api.example.com', {
-      apiKey: '12345',
-      sdkVersion: 'foobar',
-      sdkName: 'ExampleSDK',
+    const apiEndpoints = new ApiEndpoints({
+      baseUrl: 'http://api.example.com',
+      queryParams: {
+        apiKey: '12345',
+        sdkVersion: 'foobar',
+        sdkName: 'ExampleSDK',
+      },
     });
     expect(apiEndpoints.endpoint('/data').toString()).toEqual(
       'http://api.example.com/data?apiKey=12345&sdkVersion=foobar&sdkName=ExampleSDK',
@@ -17,10 +20,13 @@ describe('ApiEndpoints', () => {
   });
 
   it('should use default base URL if not provided', () => {
-    const apiEndpoints = new ApiEndpoints(undefined, {
-      apiKey: '12345',
-      sdkVersion: 'foobar',
-      sdkName: 'ExampleSDK',
+    const apiEndpoints = new ApiEndpoints({
+      baseUrl: undefined,
+      queryParams: {
+        apiKey: '12345',
+        sdkVersion: 'foobar',
+        sdkName: 'ExampleSDK',
+      },
     });
     expect(apiEndpoints.endpoint('/data').toString()).toEqual(
       `${DEFAULT_BASE_URL}/data?apiKey=12345&sdkVersion=foobar&sdkName=ExampleSDK`,

--- a/src/api-endpoint.spec.ts
+++ b/src/api-endpoint.spec.ts
@@ -21,7 +21,6 @@ describe('ApiEndpoints', () => {
 
   it('should use default base URL if not provided', () => {
     const apiEndpoints = new ApiEndpoints({
-      baseUrl: undefined,
       queryParams: {
         apiKey: '12345',
         sdkVersion: 'foobar',
@@ -33,6 +32,14 @@ describe('ApiEndpoints', () => {
     );
     expect(apiEndpoints.ufcEndpoint().toString()).toEqual(
       `${DEFAULT_BASE_URL}/flag-config/v1/config?apiKey=12345&sdkVersion=foobar&sdkName=ExampleSDK`,
+    );
+  });
+
+  it('should not append query parameters if not provided', () => {
+    const apiEndpoints = new ApiEndpoints({});
+    expect(apiEndpoints.endpoint('/data').toString()).toEqual(`${DEFAULT_BASE_URL}/data`);
+    expect(apiEndpoints.ufcEndpoint().toString()).toEqual(
+      `${DEFAULT_BASE_URL}/flag-config/v1/config`,
     );
   });
 });

--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -1,8 +1,8 @@
 import { BASE_URL as DEFAULT_BASE_URL, UFC_ENDPOINT } from './constants';
-import { ISdkParams } from './http-client';
+import { IQueryParams } from './http-client';
 
 interface IApiEndpointsParams {
-  queryParams: ISdkParams;
+  queryParams: IQueryParams;
   baseUrl?: string;
 }
 

--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -1,14 +1,14 @@
 import { BASE_URL as DEFAULT_BASE_URL, UFC_ENDPOINT } from './constants';
 import { ISdkParams } from './http-client';
 
-interface IApiEndpointParams {
+interface IApiEndpointsParams {
   queryParams: ISdkParams;
   baseUrl?: string;
 }
 
 /** Utility class for constructing an Eppo API endpoint URL given a provided baseUrl and query parameters */
 export default class ApiEndpoints {
-  constructor(private readonly params: IApiEndpointParams) {
+  constructor(private readonly params: IApiEndpointsParams) {
     this.params.baseUrl = params.baseUrl ?? DEFAULT_BASE_URL;
   }
 

--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -1,10 +1,12 @@
 import { ISdkParams } from './http-client';
 
+import { BASE_URL as DEFAULT_BASE_URL } from './constants';
+
 const UFC_ENDPOINT = '/flag-config/v1/config';
 
 /** Utility class for constructing an Eppo API endpoint URL given a provided baseUrl and query parameters */
 export default class ApiEndpoints {
-  constructor(private readonly baseUrl: string, private readonly queryParams: ISdkParams) {}
+  constructor(private readonly baseUrl: string = DEFAULT_BASE_URL, private readonly queryParams: ISdkParams) { }
 
   endpoint(resource: string): URL {
     const url = new URL(this.baseUrl + resource);

--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -1,12 +1,12 @@
+import { BASE_URL as DEFAULT_BASE_URL, UFC_ENDPOINT } from './constants';
 import { ISdkParams } from './http-client';
-
-import { BASE_URL as DEFAULT_BASE_URL } from './constants';
-
-const UFC_ENDPOINT = '/flag-config/v1/config';
 
 /** Utility class for constructing an Eppo API endpoint URL given a provided baseUrl and query parameters */
 export default class ApiEndpoints {
-  constructor(private readonly baseUrl: string = DEFAULT_BASE_URL, private readonly queryParams: ISdkParams) { }
+  constructor(
+    private readonly baseUrl: string = DEFAULT_BASE_URL,
+    private readonly queryParams: ISdkParams,
+  ) {}
 
   endpoint(resource: string): URL {
     const url = new URL(this.baseUrl + resource);

--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -1,16 +1,22 @@
 import { BASE_URL as DEFAULT_BASE_URL, UFC_ENDPOINT } from './constants';
 import { ISdkParams } from './http-client';
 
+interface IApiEndpointParams {
+  queryParams: ISdkParams;
+  baseUrl?: string;
+}
+
 /** Utility class for constructing an Eppo API endpoint URL given a provided baseUrl and query parameters */
 export default class ApiEndpoints {
-  constructor(
-    private readonly baseUrl: string = DEFAULT_BASE_URL,
-    private readonly queryParams: ISdkParams,
-  ) {}
+  constructor(private readonly params: IApiEndpointParams) {
+    this.params.baseUrl = params.baseUrl ?? DEFAULT_BASE_URL;
+  }
 
   endpoint(resource: string): URL {
-    const url = new URL(this.baseUrl + resource);
-    Object.entries(this.queryParams).forEach(([key, value]) => url.searchParams.append(key, value));
+    const url = new URL(this.params.baseUrl + resource);
+    Object.entries(this.params.queryParams).forEach(([key, value]) =>
+      url.searchParams.append(key, value),
+    );
     return url;
   }
 

--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -2,7 +2,7 @@ import { BASE_URL as DEFAULT_BASE_URL, UFC_ENDPOINT } from './constants';
 import { IQueryParams } from './http-client';
 
 interface IApiEndpointsParams {
-  queryParams: IQueryParams;
+  queryParams?: IQueryParams;
   baseUrl?: string;
 }
 
@@ -14,7 +14,7 @@ export default class ApiEndpoints {
 
   endpoint(resource: string): URL {
     const url = new URL(this.params.baseUrl + resource);
-    Object.entries(this.params.queryParams).forEach(([key, value]) =>
+    Object.entries(this.params.queryParams ?? {}).forEach(([key, value]) =>
       url.searchParams.append(key, value),
     );
     return url;

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -23,10 +23,13 @@ import { Flag, ObfuscatedFlag, VariationType } from '../interfaces';
 import EppoClient, { FlagConfigurationRequestParameters, checkTypeMatch } from './eppo-client';
 
 export async function init(configurationStore: IConfigurationStore<Flag | ObfuscatedFlag>) {
-  const apiEndpoints = new ApiEndpoints('http://127.0.0.1:4000', {
-    apiKey: 'dummy',
-    sdkName: 'js-client-sdk-common',
-    sdkVersion: '1.0.0',
+  const apiEndpoints = new ApiEndpoints({
+    baseUrl: 'http://127.0.0.1:4000',
+    queryParams: {
+      apiKey: 'dummy',
+      sdkName: 'js-client-sdk-common',
+      sdkVersion: '1.0.0',
+    },
   });
   const httpClient = new FetchHttpClient(apiEndpoints, 1000);
   const configurationRequestor = new FlagConfigurationRequestor(configurationStore, httpClient);

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -172,7 +172,7 @@ export default class EppoClient implements IEppoClient {
     private configurationStore: IConfigurationStore<Flag | ObfuscatedFlag>,
     private configurationRequestParameters?: FlagConfigurationRequestParameters,
     private readonly isObfuscated = false,
-  ) { }
+  ) {}
 
   public setConfigurationRequestParameters(
     configurationRequestParameters: FlagConfigurationRequestParameters,

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -172,7 +172,7 @@ export default class EppoClient implements IEppoClient {
     private configurationStore: IConfigurationStore<Flag | ObfuscatedFlag>,
     private configurationRequestParameters?: FlagConfigurationRequestParameters,
     private readonly isObfuscated = false,
-  ) {}
+  ) { }
 
   public setConfigurationRequestParameters(
     configurationRequestParameters: FlagConfigurationRequestParameters,
@@ -217,7 +217,10 @@ export default class EppoClient implements IEppoClient {
       skipInitialPoll = false,
     } = this.configurationRequestParameters;
     // todo: Inject the chain of dependencies below
-    const apiEndpoints = new ApiEndpoints(baseUrl, { apiKey, sdkName, sdkVersion });
+    const apiEndpoints = new ApiEndpoints({
+      baseUrl,
+      queryParams: { apiKey, sdkName, sdkVersion },
+    });
     const httpClient = new FetchHttpClient(apiEndpoints, requestTimeoutMs);
     const configurationRequestor = new FlagConfigurationRequestor(
       this.configurationStore,

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -8,7 +8,6 @@ import {
 } from '../cache/abstract-assignment-cache';
 import { IConfigurationStore } from '../configuration-store/configuration-store';
 import {
-  BASE_URL as DEFAULT_BASE_URL,
   DEFAULT_INITIAL_CONFIG_REQUEST_RETRIES,
   DEFAULT_POLL_CONFIG_REQUEST_RETRIES,
   DEFAULT_REQUEST_TIMEOUT_MS as DEFAULT_REQUEST_TIMEOUT_MS,
@@ -173,7 +172,7 @@ export default class EppoClient implements IEppoClient {
     private configurationStore: IConfigurationStore<Flag | ObfuscatedFlag>,
     private configurationRequestParameters?: FlagConfigurationRequestParameters,
     private readonly isObfuscated = false,
-  ) {}
+  ) { }
 
   public setConfigurationRequestParameters(
     configurationRequestParameters: FlagConfigurationRequestParameters,
@@ -208,7 +207,7 @@ export default class EppoClient implements IEppoClient {
       apiKey,
       sdkName,
       sdkVersion,
-      baseUrl = DEFAULT_BASE_URL,
+      baseUrl, // Default is set in ApiEndpoints constructor if undefined
       requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
       numInitialRequestRetries = DEFAULT_INITIAL_CONFIG_REQUEST_RETRIES,
       numPollRequestRetries = DEFAULT_POLL_CONFIG_REQUEST_RETRIES,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export const POLL_JITTER_PCT = 0.1;
 export const DEFAULT_INITIAL_CONFIG_REQUEST_RETRIES = 1;
 export const DEFAULT_POLL_CONFIG_REQUEST_RETRIES = 7;
 export const BASE_URL = 'https://fscdn.eppo.cloud/api';
+export const UFC_ENDPOINT = '/flag-config/v1/config';
 export const SESSION_ASSIGNMENT_CONFIG_LOADED = 'eppo-session-assignment-config-loaded';
 export const NULL_SENTINEL = 'EPPO_NULL';
 // number of logging events that may be queued while waiting for initialization

--- a/src/http-client.spec.ts
+++ b/src/http-client.spec.ts
@@ -1,15 +1,15 @@
 import ApiEndpoints from './api-endpoints';
-import FetchHttpClient, { HttpRequestError, ISdkParams } from './http-client';
+import FetchHttpClient, { HttpRequestError, IQueryParams } from './http-client';
 
 describe('FetchHttpClient', () => {
   const baseUrl = 'http://api.example.com';
-  const sdkParams: ISdkParams = {
+  const queryParams: IQueryParams = {
     apiKey: '12345',
     sdkVersion: '1.0',
     sdkName: 'ExampleSDK',
   };
   const timeout = 5000; // 5 seconds
-  const apiEndpoints = new ApiEndpoints(baseUrl, sdkParams);
+  const apiEndpoints = new ApiEndpoints({ baseUrl, queryParams });
   const httpClient = new FetchHttpClient(apiEndpoints, timeout);
 
   beforeEach(() => {

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -1,7 +1,7 @@
 import ApiEndpoints from './api-endpoints';
 import { Flag } from './interfaces';
 
-export interface ISdkParams {
+export interface IQueryParams {
   apiKey: string;
   sdkVersion: string;
   sdkName: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import { MemoryStore, MemoryOnlyConfigurationStore } from './configuration-store
 import * as constants from './constants';
 import ApiEndpoints from './api-endpoints';
 import FlagConfigRequestor from './flag-configuration-requestor';
-import HttpClient from './http-client';
+import HttpClient, { ISdkParams } from './http-client';
 import { Flag, VariationType } from './interfaces';
 import { AttributeType, SubjectAttributes } from './types';
 import * as validation from './validation';
@@ -68,4 +68,5 @@ export {
   VariationType,
   AttributeType,
   SubjectAttributes,
+  ISdkParams
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
 import { HybridConfigurationStore } from './configuration-store/hybrid.store';
 import { MemoryStore, MemoryOnlyConfigurationStore } from './configuration-store/memory.store';
 import * as constants from './constants';
+import ApiEndpoints from './api-endpoints';
 import FlagConfigRequestor from './flag-configuration-requestor';
 import HttpClient from './http-client';
 import { Flag, VariationType } from './interfaces';
@@ -37,6 +38,7 @@ export {
   EppoClient,
   IEppoClient,
   constants,
+  ApiEndpoints,
   FlagConfigRequestor,
   HttpClient,
   validation,

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,5 +68,4 @@ export {
   VariationType,
   AttributeType,
   SubjectAttributes,
-  ISdkParams
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import ApiEndpoints from './api-endpoints';
 import { logger } from './application-logger';
 import { IAssignmentHooks } from './assignment-hooks';
 import { IAssignmentLogger, IAssignmentEvent } from './assignment-logger';
@@ -22,9 +23,8 @@ import {
 import { HybridConfigurationStore } from './configuration-store/hybrid.store';
 import { MemoryStore, MemoryOnlyConfigurationStore } from './configuration-store/memory.store';
 import * as constants from './constants';
-import ApiEndpoints from './api-endpoints';
 import FlagConfigRequestor from './flag-configuration-requestor';
-import HttpClient, { ISdkParams } from './http-client';
+import HttpClient from './http-client';
 import { Flag, VariationType } from './interfaces';
 import { AttributeType, SubjectAttributes } from './types';
 import * as validation from './validation';


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Export `ApiEndpoints` so we can expose a `getConfigUrl` method in the client SDK

## Description
[//]: # (Describe your changes in detail)

Intended usage in js-client-sdk

```javascript
import { sdkName, sdkVersion } from './sdk-data';

export function getConfigUrl(apiKey: string, baseUrl?: string): URL {
  const queryParams = { sdkName, sdkVersion, apiKey };
  return new ApiEndpoints({ baseUrl, queryParams }).ufcEndpoint();
}

// And when this method is called, it returns the fully formed URL
getConfigUrl('abcd1234') --> "https://fscdn.eppo.cloud/api/flag-config/v1/config?apiKey=abcd1234&sdkVersion=3.1.4&sdkName=js-client-sdk"

// And the default base URL can be overridden if provided
getConfigUrl('abcd1234', 'http://api.example.com') --> "http://api.example.com/flag-config/v1/config?apiKey=abcd1234&sdkVersion=3.1.4&sdkName=js-client-sdk"
```

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
