### PR TITLE
FF-2498 Evaluation Details, excluding config fetch/publish time

### DIFF
--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -247,6 +247,13 @@ describe('EppoClient E2E test', () => {
             orderPosition: 0,
           },
           unmatchedAllocations: [],
+          unevaluatedAllocations: [
+            {
+              key: '50/50 split',
+              allocationEvaluationCode: AllocationEvaluationCode.UNEVALUATED,
+              orderPosition: 1,
+            },
+          ],
         };
         expect(result).toEqual(expected);
       });
@@ -266,7 +273,8 @@ describe('EppoClient E2E test', () => {
           variationKey: 'two',
           variationValue: 2,
           flagEvaluationCode: 'MATCH',
-          flagEvaluationDescription: 'alice belongs to the range of traffic assigned to "two".',
+          flagEvaluationDescription:
+            'alice belongs to the range of traffic assigned to "two" defined in allocation "50/50 split".',
           matchedRule: null,
           matchedAllocation: {
             key: '50/50 split',
@@ -280,6 +288,7 @@ describe('EppoClient E2E test', () => {
               orderPosition: 0,
             },
           ],
+          unevaluatedAllocations: [],
         };
         expect(result).toEqual(expected);
       });
@@ -327,6 +336,13 @@ describe('EppoClient E2E test', () => {
               orderPosition: 1,
             },
           ],
+          unevaluatedAllocations: [
+            {
+              key: 'rollout',
+              allocationEvaluationCode: AllocationEvaluationCode.UNEVALUATED,
+              orderPosition: 3,
+            },
+          ],
         };
         expect(result).toEqual(expected);
       });
@@ -345,7 +361,8 @@ describe('EppoClient E2E test', () => {
           matchedRule: null,
           matchedAllocation: null,
           unmatchedAllocations: [],
-        });
+          unevaluatedAllocations: [],
+        } as AssignmentDetails<number>);
       });
     });
 

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -17,10 +17,16 @@ import { IConfigurationStore } from '../configuration-store/configuration-store'
 import { MemoryOnlyConfigurationStore } from '../configuration-store/memory.store';
 import { MAX_EVENT_QUEUE_SIZE, POLL_INTERVAL_MS, POLL_JITTER_PCT } from '../constants';
 import FlagConfigurationRequestor from '../flag-configuration-requestor';
+import { AllocationEvaluationCode } from '../flag-evaluation-details';
 import FetchHttpClient from '../http-client';
 import { Flag, ObfuscatedFlag, VariationType } from '../interfaces';
+import { OperatorType } from '../rules';
 
-import EppoClient, { FlagConfigurationRequestParameters, checkTypeMatch } from './eppo-client';
+import EppoClient, {
+  AssignmentDetails,
+  FlagConfigurationRequestParameters,
+  checkTypeMatch,
+} from './eppo-client';
 
 export async function init(configurationStore: IConfigurationStore<Flag | ObfuscatedFlag>) {
   const apiEndpoints = new ApiEndpoints({
@@ -206,6 +212,141 @@ describe('EppoClient E2E test', () => {
 
     afterAll(() => {
       jest.restoreAllMocks();
+    });
+
+    describe('get*AssignmentDetails', () => {
+      it('should set the details for a matched rule', () => {
+        const client = new EppoClient(storage);
+        client.setIsGracefulFailureMode(false);
+        const subjectAttributes = { email: 'alice@mycompany.com', country: 'US' };
+        const result = client.getIntegerAssignmentDetails(
+          'integer-flag',
+          'alice',
+          subjectAttributes,
+          0,
+        );
+        const expected: AssignmentDetails<number> = {
+          value: 3,
+          variationKey: 'three',
+          variationValue: 3,
+          flagEvaluationCode: 'MATCH',
+          flagEvaluationDescription:
+            'Supplied attributes match rules defined in allocation "targeted allocation".',
+          matchedRule: {
+            conditions: [
+              {
+                attribute: 'country',
+                operator: OperatorType.ONE_OF,
+                value: ['US', 'Canada', 'Mexico'],
+              },
+            ],
+          },
+          matchedAllocation: {
+            key: 'targeted allocation',
+            allocationEvaluationCode: AllocationEvaluationCode.MATCH,
+            orderPosition: 0,
+          },
+          unmatchedAllocations: [],
+        };
+        expect(result).toEqual(expected);
+      });
+
+      it('should set the details for a matched split', () => {
+        const client = new EppoClient(storage);
+        client.setIsGracefulFailureMode(false);
+        const subjectAttributes = { email: 'alice@mycompany.com', country: 'Brazil' };
+        const result = client.getIntegerAssignmentDetails(
+          'integer-flag',
+          'alice',
+          subjectAttributes,
+          0,
+        );
+        const expected: AssignmentDetails<number> = {
+          value: 2,
+          variationKey: 'two',
+          variationValue: 2,
+          flagEvaluationCode: 'MATCH',
+          flagEvaluationDescription: 'alice belongs to the range of traffic assigned to "two".',
+          matchedRule: null,
+          matchedAllocation: {
+            key: '50/50 split',
+            allocationEvaluationCode: AllocationEvaluationCode.MATCH,
+            orderPosition: 1,
+          },
+          unmatchedAllocations: [
+            {
+              key: 'targeted allocation',
+              allocationEvaluationCode: AllocationEvaluationCode.FAILING_RULE,
+              orderPosition: 0,
+            },
+          ],
+        };
+        expect(result).toEqual(expected);
+      });
+
+      it('should handle matching a split allocation with a matched rule', () => {
+        const client = new EppoClient(storage);
+        client.setIsGracefulFailureMode(false);
+        const subjectAttributes = { id: 'alice', email: 'alice@external.com', country: 'Brazil' };
+        const result = client.getStringAssignmentDetails(
+          'new-user-onboarding',
+          'alice',
+          subjectAttributes,
+          '',
+        );
+        const expected: AssignmentDetails<string> = {
+          value: 'control',
+          flagEvaluationCode: 'MATCH',
+          flagEvaluationDescription:
+            'Supplied attributes match rules defined in allocation "experiment" and alice belongs to the range of traffic assigned to "control".',
+          variationKey: 'control',
+          variationValue: 'control',
+          matchedRule: {
+            conditions: [
+              {
+                attribute: 'country',
+                operator: OperatorType.NOT_ONE_OF,
+                value: ['US', 'Canada', 'Mexico'],
+              },
+            ],
+          },
+          matchedAllocation: {
+            key: 'experiment',
+            allocationEvaluationCode: AllocationEvaluationCode.MATCH,
+            orderPosition: 2,
+          },
+          unmatchedAllocations: [
+            {
+              key: 'id rule',
+              allocationEvaluationCode: AllocationEvaluationCode.FAILING_RULE,
+              orderPosition: 0,
+            },
+            {
+              key: 'internal users',
+              allocationEvaluationCode: AllocationEvaluationCode.FAILING_RULE,
+              orderPosition: 1,
+            },
+          ],
+        };
+        expect(result).toEqual(expected);
+      });
+
+      it('should handle unrecognized flags', () => {
+        const client = new EppoClient(storage);
+        client.setIsGracefulFailureMode(false);
+        const result = client.getIntegerAssignmentDetails('asdf', 'alice', {}, 0);
+        console.log(JSON.stringify(result, null, 2));
+        expect(result).toEqual({
+          value: 0,
+          flagEvaluationCode: 'FLAG_UNRECOGNIZED_OR_DISABLED',
+          flagEvaluationDescription: 'Unrecognized or disabled flag: asdf',
+          variationKey: null,
+          variationValue: null,
+          matchedRule: null,
+          matchedAllocation: null,
+          unmatchedAllocations: [],
+        });
+      });
     });
 
     it.each(readAssignmentTestData())(

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -404,7 +404,7 @@ export default class EppoClient {
       };
     } catch (error) {
       const eppoValue = this.rethrowIfNotGraceful(error, defaultValue);
-      const flagEvaluationDetails = new FlagEvaluationDetailsBuilder().buildForNoneResult(
+      const flagEvaluationDetails = new FlagEvaluationDetailsBuilder([]).buildForNoneResult(
         'ASSIGNMENT_ERROR',
         `Assignment Error: ${error.message}`,
       );
@@ -445,7 +445,7 @@ export default class EppoClient {
     validateNotBlank(flagKey, 'Invalid argument: flagKey cannot be blank');
 
     const flag = this.getFlag(flagKey);
-    const flagEvaluationDetailsBuilder = new FlagEvaluationDetailsBuilder();
+    const flagEvaluationDetailsBuilder = new FlagEvaluationDetailsBuilder(flag?.allocations ?? []);
 
     if (flag === null) {
       logger.warn(`[Eppo SDK] No assigned variation. Flag not found: ${flagKey}`);

--- a/src/evaluator.spec.ts
+++ b/src/evaluator.spec.ts
@@ -559,7 +559,7 @@ describe('matchesRules', () => {
       const rules: Rule[] = [];
       const subjectAttributes = { id: 'test-subject' };
       const obfuscated = false;
-      expect(matchesRules(rules, subjectAttributes, obfuscated)).toBeTruthy();
+      expect(matchesRules(rules, subjectAttributes, obfuscated).matched).toBeTruthy();
     });
 
     it('should return true when a rule matches', () => {
@@ -576,7 +576,7 @@ describe('matchesRules', () => {
       ];
       const subjectAttributes = { id: 'test-subject', age: 20 };
       const obfuscated = false;
-      expect(matchesRules(rules, subjectAttributes, obfuscated)).toBeTruthy();
+      expect(matchesRules(rules, subjectAttributes, obfuscated).matched).toBeTruthy();
     });
 
     it('should return true when one of two rules matches', () => {
@@ -602,7 +602,7 @@ describe('matchesRules', () => {
       ];
       const subjectAttributes = { id: 'test-subject', age: 10 };
       const obfuscated = false;
-      expect(matchesRules(rules, subjectAttributes, obfuscated)).toBeTruthy();
+      expect(matchesRules(rules, subjectAttributes, obfuscated).matched).toBeTruthy();
     });
 
     it('should return true when null or rule is passed', () => {
@@ -627,9 +627,11 @@ describe('matchesRules', () => {
         },
       ];
       const obfuscated = false;
-      expect(matchesRules(rules, { id: 'test-subject', age: 20 }, obfuscated)).toBeTruthy();
-      expect(matchesRules(rules, { id: 'test-subject', age: 10 }, obfuscated)).toBeFalsy();
-      expect(matchesRules(rules, { id: 'test-subject', country: 'UK' }, obfuscated)).toBeTruthy();
+      expect(matchesRules(rules, { id: 'test-subject', age: 20 }, obfuscated).matched).toBeTruthy();
+      expect(matchesRules(rules, { id: 'test-subject', age: 10 }, obfuscated).matched).toBeFalsy();
+      expect(
+        matchesRules(rules, { id: 'test-subject', country: 'UK' }, obfuscated).matched,
+      ).toBeTruthy();
     });
 
     it('should return false when no rules match', () => {
@@ -646,7 +648,7 @@ describe('matchesRules', () => {
       ];
       const subjectAttributes = { id: 'test-subject', age: 16 };
       const obfuscated = false;
-      expect(matchesRules(rules, subjectAttributes, obfuscated)).toBeFalsy();
+      expect(matchesRules(rules, subjectAttributes, obfuscated).matched).toBeFalsy();
     });
   });
 });

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1,4 +1,10 @@
-import { Flag, Shard, Range, Variation } from './interfaces';
+import {
+  AllocationEvaluation,
+  AllocationEvaluationCode,
+  FlagEvaluationDetails,
+  FlagEvaluationDetailsBuilder,
+} from './flag-evaluation-details';
+import { Flag, Shard, Range, Variation, Allocation, Split } from './interfaces';
 import { Rule, matchesRule } from './rules';
 import { MD5Sharder, Sharder } from './sharders';
 import { SubjectAttributes } from './types';
@@ -11,6 +17,7 @@ export interface FlagEvaluation {
   variation: Variation | null;
   extraLogging: Record<string, string>;
   doLog: boolean;
+  flagEvaluationDetails: FlagEvaluationDetails;
 }
 
 export class Evaluator {
@@ -26,43 +33,110 @@ export class Evaluator {
     subjectAttributes: SubjectAttributes,
     obfuscated: boolean,
   ): FlagEvaluation {
+    const flagEvaluationDetailsBuilder = new FlagEvaluationDetailsBuilder();
+
     if (!flag.enabled) {
-      return noneResult(flag.key, subjectKey, subjectAttributes);
+      return noneResult(
+        flag.key,
+        subjectKey,
+        subjectAttributes,
+        flagEvaluationDetailsBuilder.buildForNoneResult(
+          'FLAG_UNRECOGNIZED_OR_DISABLED',
+          `Unrecognized or disabled flag: ${flag.key}`,
+        ),
+      );
     }
 
     const now = new Date();
-    for (const allocation of flag.allocations) {
-      if (allocation.startAt && now < new Date(allocation.startAt)) continue;
-      if (allocation.endAt && now > new Date(allocation.endAt)) continue;
+    const unmatchedAllocations: Array<AllocationEvaluation> = [];
+    for (let i = 0; i < flag.allocations.length; i++) {
+      const allocation = flag.allocations[i];
+      const addUnmatchedAllocation = (code: AllocationEvaluationCode) => {
+        unmatchedAllocations.push({
+          key: allocation.key,
+          allocationEvaluationCode: code,
+          orderPosition: i,
+        });
+      };
 
-      if (
-        matchesRules(allocation?.rules ?? [], { id: subjectKey, ...subjectAttributes }, obfuscated)
-      ) {
+      if (allocation.startAt && now < new Date(allocation.startAt)) {
+        addUnmatchedAllocation(AllocationEvaluationCode.BEFORE_START_TIME);
+        continue;
+      }
+      if (allocation.endAt && now > new Date(allocation.endAt)) {
+        addUnmatchedAllocation(AllocationEvaluationCode.AFTER_END_TIME);
+        continue;
+      }
+      const { matched, matchedRule } = matchesRules(
+        allocation?.rules ?? [],
+        { id: subjectKey, ...subjectAttributes },
+        obfuscated,
+      );
+      if (matched) {
         for (const split of allocation.splits) {
           if (
             split.shards.every((shard) => this.matchesShard(shard, subjectKey, flag.totalShards))
           ) {
+            const variation = flag.variations[split.variationKey];
+            const flagEvaluationDetails = flagEvaluationDetailsBuilder
+              .setMatch(i, variation, allocation, matchedRule, unmatchedAllocations)
+              .build(
+                'MATCH',
+                this.getMatchedEvaluationDetailsMessage(allocation, split, subjectKey),
+              );
             return {
               flagKey: flag.key,
               subjectKey,
               subjectAttributes,
               allocationKey: allocation.key,
-              variation: flag.variations[split.variationKey],
+              variation,
               extraLogging: split.extraLogging ?? {},
               doLog: allocation.doLog,
+              flagEvaluationDetails,
             };
           }
         }
+        // matched, but does not fall within split range
+        addUnmatchedAllocation(AllocationEvaluationCode.TRAFFIC_EXPOSURE_MISS);
+      } else {
+        addUnmatchedAllocation(AllocationEvaluationCode.FAILING_RULE);
       }
     }
-
-    return noneResult(flag.key, subjectKey, subjectAttributes);
+    return noneResult(
+      flag.key,
+      subjectKey,
+      subjectAttributes,
+      flagEvaluationDetailsBuilder.buildForNoneResult(
+        'DEFAULT_ALLOCATION',
+        'No allocations matched. Falling back to "Default Allocation", serving NULL',
+        unmatchedAllocations,
+      ),
+    );
   }
 
   matchesShard(shard: Shard, subjectKey: string, totalShards: number): boolean {
     const assignedShard = this.sharder.getShard(hashKey(shard.salt, subjectKey), totalShards);
     return shard.ranges.some((range) => isInShardRange(assignedShard, range));
   }
+
+  private getMatchedEvaluationDetailsMessage = (
+    allocation: Allocation,
+    split: Split,
+    subjectKey: string,
+  ): string => {
+    const hasDefinedRules = !!allocation.rules?.length;
+    const isExperiment = allocation.splits.length > 1;
+    const isPartialRollout = split.shards.length > 1;
+    const isExperimentOrPartialRollout = isExperiment || isPartialRollout;
+
+    if (hasDefinedRules && isExperimentOrPartialRollout) {
+      return `Supplied attributes match rules defined in allocation "${allocation.key}" and ${subjectKey} belongs to the range of traffic assigned to "${split.variationKey}".`;
+    }
+    if (hasDefinedRules && !isExperimentOrPartialRollout) {
+      return `Supplied attributes match rules defined in allocation "${allocation.key}".`;
+    }
+    return `${subjectKey} belongs to the range of traffic assigned to "${split.variationKey}" defined in allocation "${allocation.key}".`;
+  };
 }
 
 export function isInShardRange(shard: number, range: Range): boolean {
@@ -77,6 +151,7 @@ export function noneResult(
   flagKey: string,
   subjectKey: string,
   subjectAttributes: SubjectAttributes,
+  flagEvaluationDetails: FlagEvaluationDetails,
 ): FlagEvaluation {
   return {
     flagKey,
@@ -86,6 +161,7 @@ export function noneResult(
     variation: null,
     extraLogging: {},
     doLog: false,
+    flagEvaluationDetails,
   };
 }
 
@@ -93,6 +169,28 @@ export function matchesRules(
   rules: Rule[],
   subjectAttributes: SubjectAttributes,
   obfuscated: boolean,
-): boolean {
-  return !rules.length || rules.some((rule) => matchesRule(rule, subjectAttributes, obfuscated));
+): { matched: boolean; matchedRule: Rule | null } {
+  if (!rules.length) {
+    return {
+      matched: true,
+      matchedRule: null,
+    };
+  }
+  let matchedRule: Rule | null = null;
+  const hasMatch = rules.some((rule) => {
+    const matched = matchesRule(rule, subjectAttributes, obfuscated);
+    if (matched) {
+      matchedRule = rule;
+    }
+    return matched;
+  });
+  return hasMatch
+    ? {
+        matched: true,
+        matchedRule,
+      }
+    : {
+        matched: false,
+        matchedRule: null,
+      };
 }

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -33,7 +33,7 @@ export class Evaluator {
     subjectAttributes: SubjectAttributes,
     obfuscated: boolean,
   ): FlagEvaluation {
-    const flagEvaluationDetailsBuilder = new FlagEvaluationDetailsBuilder();
+    const flagEvaluationDetailsBuilder = new FlagEvaluationDetailsBuilder(flag.allocations);
 
     if (!flag.enabled) {
       return noneResult(
@@ -106,11 +106,12 @@ export class Evaluator {
       flag.key,
       subjectKey,
       subjectAttributes,
-      flagEvaluationDetailsBuilder.buildForNoneResult(
-        'DEFAULT_ALLOCATION',
-        'No allocations matched. Falling back to "Default Allocation", serving NULL',
-        unmatchedAllocations,
-      ),
+      flagEvaluationDetailsBuilder
+        .setNoMatchFound(unmatchedAllocations)
+        .build(
+          'DEFAULT_ALLOCATION_NULL',
+          'No allocations matched. Falling back to "Default Allocation", serving NULL',
+        ),
     );
   }
 

--- a/src/flag-evaluation-details.ts
+++ b/src/flag-evaluation-details.ts
@@ -1,0 +1,98 @@
+import { Allocation, Variation } from './interfaces';
+import { Rule } from './rules';
+
+export const flagEvaluationCodes = [
+  'MATCH',
+  'FLAG_UNRECOGNIZED_OR_DISABLED',
+  'TYPE_MISMATCH',
+  'ASSIGNMENT_ERROR',
+  'DEFAULT_ALLOCATION',
+] as const;
+
+export type FlagEvaluationCode = typeof flagEvaluationCodes[number];
+
+export enum AllocationEvaluationCode {
+  MATCH = 'MATCH',
+  BEFORE_START_TIME = 'BEFORE_START_TIME',
+  AFTER_END_TIME = 'AFTER_END_TIME',
+  FAILING_RULE = 'FAILING_RULE',
+  TRAFFIC_EXPOSURE_MISS = 'TRAFFIC_EXPOSURE_MISS',
+}
+
+export interface AllocationEvaluation {
+  key: string;
+  allocationEvaluationCode: AllocationEvaluationCode;
+  orderPosition: number;
+}
+
+export interface FlagEvaluationDetails {
+  variationKey: string | null;
+  variationValue: Variation['value'] | null;
+  flagEvaluationCode: FlagEvaluationCode;
+  flagEvaluationDescription: string;
+  matchedRule: Rule | null;
+  matchedAllocation: AllocationEvaluation | null;
+  unmatchedAllocations: Array<AllocationEvaluation>;
+}
+
+export class FlagEvaluationDetailsBuilder {
+  private variationKey: FlagEvaluationDetails['variationKey'];
+  private variationValue: FlagEvaluationDetails['variationValue'];
+  private matchedRule: FlagEvaluationDetails['matchedRule'];
+  private matchedAllocation: FlagEvaluationDetails['matchedAllocation'];
+  private unmatchedAllocations: FlagEvaluationDetails['unmatchedAllocations'];
+
+  constructor() {
+    this.setNone();
+  }
+
+  setNone = (
+    unmatchedAllocations: Array<AllocationEvaluation> = [],
+  ): FlagEvaluationDetailsBuilder => {
+    this.variationKey = null;
+    this.variationValue = null;
+    this.matchedAllocation = null;
+    this.matchedRule = null;
+    this.unmatchedAllocations = unmatchedAllocations;
+    return this;
+  };
+
+  setMatch = (
+    orderPosition: number,
+    variation: Variation,
+    allocation: Allocation,
+    matchedRule: Rule | null,
+    unmatchedAllocations: Array<AllocationEvaluation>,
+  ): FlagEvaluationDetailsBuilder => {
+    this.variationKey = variation.key;
+    this.variationValue = variation.value;
+    this.matchedRule = matchedRule;
+    this.matchedAllocation = {
+      key: allocation.key,
+      allocationEvaluationCode: AllocationEvaluationCode.MATCH,
+      orderPosition,
+    };
+    this.unmatchedAllocations = unmatchedAllocations;
+    return this;
+  };
+
+  buildForNoneResult = (
+    flagEvaluationCode: FlagEvaluationCode,
+    flagEvaluationDescription: string,
+    unmatchedAllocations: Array<AllocationEvaluation> = [],
+  ): FlagEvaluationDetails =>
+    this.setNone(unmatchedAllocations).build(flagEvaluationCode, flagEvaluationDescription);
+
+  build = (
+    flagEvaluationCode: FlagEvaluationCode,
+    flagEvaluationDescription: string,
+  ): FlagEvaluationDetails => ({
+    flagEvaluationCode,
+    flagEvaluationDescription,
+    variationKey: this.variationKey,
+    variationValue: this.variationValue,
+    matchedRule: this.matchedRule,
+    matchedAllocation: this.matchedAllocation,
+    unmatchedAllocations: this.unmatchedAllocations,
+  });
+}


### PR DESCRIPTION
[FF-2498](https://linear.app/eppo/issue/FF-2498/evaluation-reasons-node-server-sdk-basic-match-reason-functionality)

## Motivation and Context
This improves the developer experience by allowing users to see how a variation is assigned. 
## Description
New "Details" assignment functions return an object with metadata that allows end-users to understand how a variation is defined.

- getBooleanAssignmentDetails
- getIntegerAssignmentDetails
- getJSONAssignmentDetails
- getNumericAssignmentDetails
- getStringAssignmentDetails

Below is an example of the object returned:

```
{
	"value": "C", // would be provided default value if variationValue is null
	"variationKey": "experiment-c",
	"variationValue": "C",
        "flagEvaluationCode": "MATCH",
	"flagEvaluationDescription": "Supplied attributes match rules defined in 'allocation-32'", 
	"matchedRule": {
		"conditions": [
			{
				"attribute": "companyId",
				"operator": "ONE_OF",
				"value": ["14", "187", "188"]
			}
		]
	},
	"unmatchedAllocations": [
		{
			"key": "allocation-43",
			"allocationEvaluationCode": "FAILING_RULE",
			"orderPosition": 0
		},
		{
			"key": "allocation-37",
			"allocationEvaluationCode": "TRAFFIC_EXPOSURE_MISS",
			"orderPosition": 1
		}
	],
	"matchedAllocation": {
		"key": "allocation-123",
		"allocationEvaluationCode": "MATCH" // See codes below
		"orderPosition": 2
	},
	"unevaluatedAllocations": [
		{
			"key": "allocation-431",
                         "allocationEvaluationCode": "UNEVALUATED",
		        "orderPosition": 3
		}
	]
}
```

## How has this been tested?
Jest unit testing

