### PR TITLE
FF-2498 Fix `this.unevaluatedAllocations` for "none"; fix comment

### DIFF
--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -254,7 +254,7 @@ export default class EppoClient {
    * @param subjectKey an identifier of the experiment subject, for example a user ID.
    * @param subjectAttributes optional attributes associated with the subject, for example name and email.
    * @param defaultValue default value to return if the subject is not part of the experiment sample
-   * @returns a boolean variation value if the subject is part of the experiment sample, otherwise the default value
+   * @returns an integer variation value if the subject is part of the experiment sample, otherwise the default value
    */
   public getIntegerAssignment = (
     flagKey: string,

--- a/src/flag-evaluation-details.ts
+++ b/src/flag-evaluation-details.ts
@@ -55,7 +55,14 @@ export class FlagEvaluationDetailsBuilder {
     this.matchedAllocation = null;
     this.matchedRule = null;
     this.unmatchedAllocations = [];
-    this.unevaluatedAllocations = [];
+    this.unevaluatedAllocations = this.allocations.map(
+      (allocation, i) =>
+        ({
+          key: allocation.key,
+          allocationEvaluationCode: AllocationEvaluationCode.UNEVALUATED,
+          orderPosition: i,
+        } as AllocationEvaluation),
+    );
     return this;
   };
 
@@ -67,14 +74,7 @@ export class FlagEvaluationDetailsBuilder {
     this.matchedAllocation = null;
     this.matchedRule = null;
     this.unmatchedAllocations = unmatchedAllocations;
-    this.unevaluatedAllocations = this.allocations.map(
-      (allocation, i) =>
-        ({
-          key: allocation.key,
-          allocationEvaluationCode: AllocationEvaluationCode.UNEVALUATED,
-          orderPosition: i,
-        } as AllocationEvaluation),
-    );
+    this.unevaluatedAllocations = [];
     return this;
   };
 


### PR DESCRIPTION
This was meant to be added to https://github.com/Eppo-exp/js-client-sdk-common/pull/99 before it was merged in to the `greg/FF-2465/evaluation-reasons` base branch. These are code review changes.