### PR TITLE
FF-2465 "Assignment Details" tests

### DIFF
--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -6,9 +6,11 @@ import {
   MOCK_UFC_RESPONSE_FILE,
   OBFUSCATED_MOCK_UFC_RESPONSE_FILE,
   SubjectTestCase,
+  getTestAssignmentDetails,
   getTestAssignments,
   readAssignmentTestData,
   readMockUFCResponse,
+  validateTestAssignmentDetails,
   validateTestAssignments,
 } from '../../test/testHelpers';
 import ApiEndpoints from '../api-endpoints';
@@ -396,6 +398,34 @@ describe('EppoClient E2E test', () => {
         );
 
         validateTestAssignments(assignments, flag);
+      },
+    );
+
+    it.each(readAssignmentTestData())(
+      'test variation assignment details',
+      async ({ flag, variationType, defaultValue, subjects }: IAssignmentTestCase) => {
+        const client = new EppoClient(storage);
+        client.setIsGracefulFailureMode(false);
+
+        const typeAssignmentDetailsFunctions = {
+          [VariationType.BOOLEAN]: client.getBooleanAssignmentDetails.bind(client),
+          [VariationType.NUMERIC]: client.getNumericAssignmentDetails.bind(client),
+          [VariationType.INTEGER]: client.getIntegerAssignmentDetails.bind(client),
+          [VariationType.STRING]: client.getStringAssignmentDetails.bind(client),
+          [VariationType.JSON]: client.getJSONAssignmentDetails.bind(client),
+        };
+
+        const assignmentFn = typeAssignmentDetailsFunctions[variationType];
+        if (!assignmentFn) {
+          throw new Error(`Unknown variation type: ${variationType}`);
+        }
+
+        const assignments = getTestAssignmentDetails(
+          { flag, variationType, defaultValue, subjects },
+          assignmentFn,
+        );
+
+        validateTestAssignmentDetails(assignments, flag);
       },
     );
   });


### PR DESCRIPTION
This will leverage the the new "assignmentDetails" test data in https://github.com/Eppo-exp/sdk-test-data/pull/30. Tests will not work until that PR is merged in.

Test failures for assignment details will look like this:
<img width="1118" alt="Screenshot 2024-06-24 at 10 15 32 AM" src="https://github.com/Eppo-exp/js-client-sdk-common/assets/1248641/7dc60ed2-e260-41c3-8ed7-6e0625097594">
