### PR TITLE
FF-2501 Include config fetch/publish time with assignment details

### DIFF
--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -234,6 +234,8 @@ describe('EppoClient E2E test', () => {
           flagEvaluationCode: 'MATCH',
           flagEvaluationDescription:
             'Supplied attributes match rules defined in allocation "targeted allocation".',
+          configFetchTime: expect.any(String),
+          configPublishTime: expect.any(String),
           matchedRule: {
             conditions: [
               {
@@ -257,7 +259,7 @@ describe('EppoClient E2E test', () => {
             },
           ],
         };
-        expect(result).toEqual(expected);
+        expect(result).toMatchObject(expected);
       });
 
       it('should set the details for a matched split', () => {
@@ -277,6 +279,8 @@ describe('EppoClient E2E test', () => {
           flagEvaluationCode: 'MATCH',
           flagEvaluationDescription:
             'alice belongs to the range of traffic assigned to "two" defined in allocation "50/50 split".',
+          configFetchTime: expect.any(String),
+          configPublishTime: expect.any(String),
           matchedRule: null,
           matchedAllocation: {
             key: '50/50 split',
@@ -292,7 +296,7 @@ describe('EppoClient E2E test', () => {
           ],
           unevaluatedAllocations: [],
         };
-        expect(result).toEqual(expected);
+        expect(result).toMatchObject(expected);
       });
 
       it('should handle matching a split allocation with a matched rule', () => {
@@ -312,6 +316,8 @@ describe('EppoClient E2E test', () => {
             'Supplied attributes match rules defined in allocation "experiment" and alice belongs to the range of traffic assigned to "control".',
           variationKey: 'control',
           variationValue: 'control',
+          configFetchTime: expect.any(String),
+          configPublishTime: expect.any(String),
           matchedRule: {
             conditions: [
               {
@@ -346,7 +352,7 @@ describe('EppoClient E2E test', () => {
             },
           ],
         };
-        expect(result).toEqual(expected);
+        expect(result).toMatchObject(expected);
       });
 
       it('should handle unrecognized flags', () => {
@@ -354,12 +360,14 @@ describe('EppoClient E2E test', () => {
         client.setIsGracefulFailureMode(false);
         const result = client.getIntegerAssignmentDetails('asdf', 'alice', {}, 0);
         console.log(JSON.stringify(result, null, 2));
-        expect(result).toEqual({
+        expect(result).toMatchObject({
           value: 0,
           flagEvaluationCode: 'FLAG_UNRECOGNIZED_OR_DISABLED',
           flagEvaluationDescription: 'Unrecognized or disabled flag: asdf',
           variationKey: null,
           variationValue: null,
+          configFetchTime: expect.any(String),
+          configPublishTime: expect.any(String),
           matchedRule: null,
           matchedAllocation: null,
           unmatchedAllocations: [],

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -234,8 +234,8 @@ describe('EppoClient E2E test', () => {
           flagEvaluationCode: 'MATCH',
           flagEvaluationDescription:
             'Supplied attributes match rules defined in allocation "targeted allocation".',
-          configFetchTime: expect.any(String),
-          configPublishTime: expect.any(String),
+          configFetchedAt: expect.any(String),
+          configPublishedAt: expect.any(String),
           matchedRule: {
             conditions: [
               {
@@ -279,8 +279,8 @@ describe('EppoClient E2E test', () => {
           flagEvaluationCode: 'MATCH',
           flagEvaluationDescription:
             'alice belongs to the range of traffic assigned to "two" defined in allocation "50/50 split".',
-          configFetchTime: expect.any(String),
-          configPublishTime: expect.any(String),
+          configFetchedAt: expect.any(String),
+          configPublishedAt: expect.any(String),
           matchedRule: null,
           matchedAllocation: {
             key: '50/50 split',
@@ -316,8 +316,8 @@ describe('EppoClient E2E test', () => {
             'Supplied attributes match rules defined in allocation "experiment" and alice belongs to the range of traffic assigned to "control".',
           variationKey: 'control',
           variationValue: 'control',
-          configFetchTime: expect.any(String),
-          configPublishTime: expect.any(String),
+          configFetchedAt: expect.any(String),
+          configPublishedAt: expect.any(String),
           matchedRule: {
             conditions: [
               {
@@ -366,8 +366,8 @@ describe('EppoClient E2E test', () => {
           flagEvaluationDescription: 'Unrecognized or disabled flag: asdf',
           variationKey: null,
           variationValue: null,
-          configFetchTime: expect.any(String),
-          configPublishTime: expect.any(String),
+          configFetchedAt: expect.any(String),
+          configPublishedAt: expect.any(String),
           matchedRule: null,
           matchedAllocation: null,
           unmatchedAllocations: [],

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -150,12 +150,15 @@ export default class EppoClient {
    * @returns a variation value if the subject is part of the experiment sample, otherwise the default value
    * @public
    */
-  public getStringAssignment = (
+  public getStringAssignment(
     flagKey: string,
     subjectKey: string,
     subjectAttributes: Record<string, AttributeType>,
     defaultValue: string,
-  ) => this.getStringAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue).value;
+  ): string {
+    return this.getStringAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue)
+      .value;
+  }
 
   /**
    * Maps a subject to a string variation for a given experiment and provides additional details about the
@@ -209,12 +212,15 @@ export default class EppoClient {
    * @param defaultValue default value to return if the subject is not part of the experiment sample
    * @returns a boolean variation value if the subject is part of the experiment sample, otherwise the default value
    */
-  public getBooleanAssignment = (
+  public getBooleanAssignment(
     flagKey: string,
     subjectKey: string,
     subjectAttributes: Record<string, AttributeType>,
     defaultValue: boolean,
-  ) => this.getBooleanAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue).value;
+  ): boolean {
+    return this.getBooleanAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue)
+      .value;
+  }
 
   /**
    * Maps a subject to a boolean variation for a given experiment and provides additional details about the
@@ -256,12 +262,15 @@ export default class EppoClient {
    * @param defaultValue default value to return if the subject is not part of the experiment sample
    * @returns an integer variation value if the subject is part of the experiment sample, otherwise the default value
    */
-  public getIntegerAssignment = (
+  public getIntegerAssignment(
     flagKey: string,
     subjectKey: string,
     subjectAttributes: Record<string, AttributeType>,
     defaultValue: number,
-  ) => this.getIntegerAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue).value;
+  ): number {
+    return this.getIntegerAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue)
+      .value;
+  }
 
   /**
    * Maps a subject to an Integer variation for a given experiment and provides additional details about the
@@ -303,12 +312,15 @@ export default class EppoClient {
    * @param defaultValue default value to return if the subject is not part of the experiment sample
    * @returns a number variation value if the subject is part of the experiment sample, otherwise the default value
    */
-  public getNumericAssignment = (
+  public getNumericAssignment(
     flagKey: string,
     subjectKey: string,
     subjectAttributes: Record<string, AttributeType>,
     defaultValue: number,
-  ) => this.getNumericAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue).value;
+  ): number {
+    return this.getNumericAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue)
+      .value;
+  }
 
   /**
    * Maps a subject to a numeric variation for a given experiment and provides additional details about the
@@ -350,12 +362,15 @@ export default class EppoClient {
    * @param defaultValue default value to return if the subject is not part of the experiment sample
    * @returns a JSON object variation value if the subject is part of the experiment sample, otherwise the default value
    */
-  public getJSONAssignment = (
+  public getJSONAssignment(
     flagKey: string,
     subjectKey: string,
     subjectAttributes: Record<string, AttributeType>,
     defaultValue: object,
-  ) => this.getJSONAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue).value;
+  ): object {
+    return this.getJSONAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue)
+      .value;
+  }
 
   public getJSONAssignmentDetails(
     flagKey: string,

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -459,11 +459,11 @@ export default class EppoClient {
     validateNotBlank(subjectKey, 'Invalid argument: subjectKey cannot be blank');
     validateNotBlank(flagKey, 'Invalid argument: flagKey cannot be blank');
 
-    const { flag, configFetchTime, configPublishTime } = this.getFlagDetails(flagKey);
+    const { flag, configFetchedAt, configPublishedAt } = this.getFlagDetails(flagKey);
     const flagEvaluationDetailsBuilder = new FlagEvaluationDetailsBuilder(
       flag?.allocations ?? [],
-      configFetchTime,
-      configPublishTime,
+      configFetchedAt,
+      configPublishedAt,
     );
 
     if (flag === null) {
@@ -497,8 +497,8 @@ export default class EppoClient {
       subjectKey,
       subjectAttributes,
       this.isObfuscated,
-      configFetchTime,
-      configPublishTime,
+      configFetchedAt,
+      configPublishedAt,
     );
     if (this.isObfuscated) {
       // flag.key is obfuscated, replace with requested flag key
@@ -528,16 +528,16 @@ export default class EppoClient {
 
   private getFlagDetails(flagKey: string): {
     flag: Flag | null;
-    configFetchTime: string;
-    configPublishTime: string;
+    configFetchedAt: string;
+    configPublishedAt: string;
   } {
     const flag = this.isObfuscated
       ? this.getObfuscatedFlag(flagKey)
       : this.configurationStore.get(flagKey);
     return {
       flag,
-      configFetchTime: this.configurationStore.getConfigFetchTime(),
-      configPublishTime: this.configurationStore.getConfigPublishTime(),
+      configFetchedAt: this.configurationStore.getConfigFetchedAt(),
+      configPublishedAt: this.configurationStore.getConfigPublishedAt(),
     };
   }
 

--- a/src/configuration-store/configuration-store.ts
+++ b/src/configuration-store/configuration-store.ts
@@ -27,10 +27,10 @@ export interface IConfigurationStore<T> {
   isInitialized(): boolean;
   isExpired(): Promise<boolean>;
   setEntries(entries: Record<string, T>): Promise<boolean>;
-  getConfigFetchTime(): string;
-  setConfigFetchTime(configFetchTime: string): void;
-  getConfigPublishTime(): string;
-  setConfigPublishTime(configPublishTime: string): void;
+  getConfigFetchedAt(): string;
+  setConfigFetchedAt(configFetchedAt: string): void;
+  getConfigPublishedAt(): string;
+  setConfigPublishedAt(configPublishedAt: string): void;
 }
 
 export interface ISyncStore<T> {

--- a/src/configuration-store/configuration-store.ts
+++ b/src/configuration-store/configuration-store.ts
@@ -26,7 +26,11 @@ export interface IConfigurationStore<T> {
   getKeys(): string[];
   isInitialized(): boolean;
   isExpired(): Promise<boolean>;
-  setEntries(entries: Record<string, T>): Promise<void>;
+  setEntries(entries: Record<string, T>): Promise<boolean>;
+  getConfigFetchTime(): string;
+  setConfigFetchTime(configFetchTime: string): void;
+  getConfigPublishTime(): string;
+  setConfigPublishTime(configPublishTime: string): void;
 }
 
 export interface ISyncStore<T> {

--- a/src/configuration-store/hybrid.store.ts
+++ b/src/configuration-store/hybrid.store.ts
@@ -8,6 +8,9 @@ export class HybridConfigurationStore<T> implements IConfigurationStore<T> {
     protected readonly persistentStore: IAsyncStore<T> | null,
   ) {}
 
+  private configFetchTime: string;
+  private configPublishTime: string;
+
   /**
    * Initialize the configuration store by loading the entries from the persistent store into the serving store.
    */
@@ -53,11 +56,28 @@ export class HybridConfigurationStore<T> implements IConfigurationStore<T> {
     return this.servingStore.getKeys();
   }
 
-  public async setEntries(entries: Record<string, T>): Promise<void> {
+  public async setEntries(entries: Record<string, T>): Promise<boolean> {
     if (this.persistentStore) {
       // Persistence store is now initialized and should mark itself accordingly.
       await this.persistentStore.setEntries(entries);
     }
     this.servingStore.setEntries(entries);
+    return true;
+  }
+
+  public getConfigFetchTime(): string {
+    return this.configFetchTime;
+  }
+
+  public setConfigFetchTime(configFetchTime: string): void {
+    this.configFetchTime = configFetchTime;
+  }
+
+  public getConfigPublishTime(): string {
+    return this.configPublishTime;
+  }
+
+  public setConfigPublishTime(configPublishTime: string): void {
+    this.configPublishTime = configPublishTime;
   }
 }

--- a/src/configuration-store/hybrid.store.ts
+++ b/src/configuration-store/hybrid.store.ts
@@ -8,8 +8,8 @@ export class HybridConfigurationStore<T> implements IConfigurationStore<T> {
     protected readonly persistentStore: IAsyncStore<T> | null,
   ) {}
 
-  private configFetchTime: string;
-  private configPublishTime: string;
+  private configFetchedAt: string;
+  private configPublishedAt: string;
 
   /**
    * Initialize the configuration store by loading the entries from the persistent store into the serving store.
@@ -65,19 +65,19 @@ export class HybridConfigurationStore<T> implements IConfigurationStore<T> {
     return true;
   }
 
-  public getConfigFetchTime(): string {
-    return this.configFetchTime;
+  public getConfigFetchedAt(): string {
+    return this.configFetchedAt;
   }
 
-  public setConfigFetchTime(configFetchTime: string): void {
-    this.configFetchTime = configFetchTime;
+  public setConfigFetchedAt(configFetchedAt: string): void {
+    this.configFetchedAt = configFetchedAt;
   }
 
-  public getConfigPublishTime(): string {
-    return this.configPublishTime;
+  public getConfigPublishedAt(): string {
+    return this.configPublishedAt;
   }
 
-  public setConfigPublishTime(configPublishTime: string): void {
-    this.configPublishTime = configPublishTime;
+  public setConfigPublishedAt(configPublishedAt: string): void {
+    this.configPublishedAt = configPublishedAt;
   }
 }

--- a/src/configuration-store/memory.store.ts
+++ b/src/configuration-store/memory.store.ts
@@ -3,6 +3,8 @@ import { IConfigurationStore, ISyncStore } from './configuration-store';
 export class MemoryStore<T> implements ISyncStore<T> {
   private store: Record<string, T> = {};
   private initialized = false;
+  private configFetchTime: string;
+  private configPublishTime: string;
 
   get(key: string): T | null {
     return this.store[key] ?? null;
@@ -25,6 +27,8 @@ export class MemoryStore<T> implements ISyncStore<T> {
 export class MemoryOnlyConfigurationStore<T> implements IConfigurationStore<T> {
   private readonly servingStore: ISyncStore<T> = new MemoryStore<T>();
   private initialized = false;
+  private configFetchTime: string;
+  private configPublishTime: string;
 
   init(): Promise<void> {
     this.initialized = true;
@@ -47,8 +51,25 @@ export class MemoryOnlyConfigurationStore<T> implements IConfigurationStore<T> {
     return this.initialized;
   }
 
-  async setEntries(entries: Record<string, T>): Promise<void> {
+  async setEntries(entries: Record<string, T>): Promise<boolean> {
     this.servingStore.setEntries(entries);
     this.initialized = true;
+    return true;
+  }
+
+  public getConfigFetchTime(): string {
+    return this.configFetchTime;
+  }
+
+  public setConfigFetchTime(configFetchTime: string): void {
+    this.configFetchTime = configFetchTime;
+  }
+
+  public getConfigPublishTime(): string {
+    return this.configPublishTime;
+  }
+
+  public setConfigPublishTime(configPublishTime: string): void {
+    this.configPublishTime = configPublishTime;
   }
 }

--- a/src/configuration-store/memory.store.ts
+++ b/src/configuration-store/memory.store.ts
@@ -3,8 +3,8 @@ import { IConfigurationStore, ISyncStore } from './configuration-store';
 export class MemoryStore<T> implements ISyncStore<T> {
   private store: Record<string, T> = {};
   private initialized = false;
-  private configFetchTime: string;
-  private configPublishTime: string;
+  private configFetchedAt: string;
+  private configPublishedAt: string;
 
   get(key: string): T | null {
     return this.store[key] ?? null;
@@ -27,8 +27,8 @@ export class MemoryStore<T> implements ISyncStore<T> {
 export class MemoryOnlyConfigurationStore<T> implements IConfigurationStore<T> {
   private readonly servingStore: ISyncStore<T> = new MemoryStore<T>();
   private initialized = false;
-  private configFetchTime: string;
-  private configPublishTime: string;
+  private configFetchedAt: string;
+  private configPublishedAt: string;
 
   init(): Promise<void> {
     this.initialized = true;
@@ -57,19 +57,19 @@ export class MemoryOnlyConfigurationStore<T> implements IConfigurationStore<T> {
     return true;
   }
 
-  public getConfigFetchTime(): string {
-    return this.configFetchTime;
+  public getConfigFetchedAt(): string {
+    return this.configFetchedAt;
   }
 
-  public setConfigFetchTime(configFetchTime: string): void {
-    this.configFetchTime = configFetchTime;
+  public setConfigFetchedAt(configFetchedAt: string): void {
+    this.configFetchedAt = configFetchedAt;
   }
 
-  public getConfigPublishTime(): string {
-    return this.configPublishTime;
+  public getConfigPublishedAt(): string {
+    return this.configPublishedAt;
   }
 
-  public setConfigPublishTime(configPublishTime: string): void {
-    this.configPublishTime = configPublishTime;
+  public setConfigPublishedAt(configPublishedAt: string): void {
+    this.configPublishedAt = configPublishedAt;
   }
 }

--- a/src/evaluator.spec.ts
+++ b/src/evaluator.spec.ts
@@ -34,7 +34,7 @@ describe('Evaluator', () => {
       totalShards: 10,
     };
 
-    const result = evaluator.evaluateFlag(flag, 'subject_key', {}, false);
+    const result = evaluator.evaluateFlag(flag, 'subject_key', {}, false, '', '');
     expect(result.flagKey).toEqual('disabled_flag');
     expect(result.allocationKey).toBeNull();
     expect(result.variation).toBeNull();
@@ -85,7 +85,7 @@ describe('Evaluator', () => {
       totalShards: 10,
     };
 
-    const result = evaluator.evaluateFlag(emptyFlag, 'subject_key', {}, false);
+    const result = evaluator.evaluateFlag(emptyFlag, 'subject_key', {}, false, '', '');
     expect(result.flagKey).toEqual('empty');
     expect(result.allocationKey).toBeNull();
     expect(result.variation).toBeNull();
@@ -115,7 +115,7 @@ describe('Evaluator', () => {
       totalShards: 10000,
     };
 
-    const result = evaluator.evaluateFlag(flag, 'user-1', {}, false);
+    const result = evaluator.evaluateFlag(flag, 'user-1', {}, false, '', '');
     expect(result.variation).toEqual({ key: 'control', value: 'control-value' });
   });
 
@@ -148,13 +148,13 @@ describe('Evaluator', () => {
       totalShards: 10000,
     };
 
-    let result = evaluator.evaluateFlag(flag, 'alice', {}, false);
+    let result = evaluator.evaluateFlag(flag, 'alice', {}, false, '', '');
     expect(result.variation).toEqual({ key: 'control', value: 'control' });
 
-    result = evaluator.evaluateFlag(flag, 'bob', {}, false);
+    result = evaluator.evaluateFlag(flag, 'bob', {}, false, '', '');
     expect(result.variation).toEqual({ key: 'control', value: 'control' });
 
-    result = evaluator.evaluateFlag(flag, 'charlie', {}, false);
+    result = evaluator.evaluateFlag(flag, 'charlie', {}, false, '', '');
     expect(result.variation).toBeNull();
   });
 
@@ -187,7 +187,7 @@ describe('Evaluator', () => {
       totalShards: 10000,
     };
 
-    const result = evaluator.evaluateFlag(flag, 'alice', { id: 'charlie' }, false);
+    const result = evaluator.evaluateFlag(flag, 'alice', { id: 'charlie' }, false, '', '');
     expect(result.variation).toBeNull();
   });
 
@@ -214,7 +214,7 @@ describe('Evaluator', () => {
       totalShards: 10,
     };
 
-    const result = evaluator.evaluateFlag(flag, 'subject_key', {}, false);
+    const result = evaluator.evaluateFlag(flag, 'subject_key', {}, false, '', '');
     expect(result.flagKey).toEqual('flag');
     expect(result.allocationKey).toEqual('default');
     expect(result.variation).toEqual(VARIATION_A);
@@ -267,6 +267,8 @@ describe('Evaluator', () => {
       'subject_key',
       { email: 'eppo@example.com' },
       false,
+      '',
+      '',
     );
     expect(result.flagKey).toEqual('flag');
     expect(result.allocationKey).toEqual('first');
@@ -314,7 +316,14 @@ describe('Evaluator', () => {
       totalShards: 10,
     };
 
-    const result = evaluator.evaluateFlag(flag, 'subject_key', { email: 'eppo@test.com' }, false);
+    const result = evaluator.evaluateFlag(
+      flag,
+      'subject_key',
+      { email: 'eppo@test.com' },
+      false,
+      '',
+      '',
+    );
     expect(result.flagKey).toEqual('flag');
     expect(result.allocationKey).toEqual('default');
     expect(result.variation).toEqual(VARIATION_A);
@@ -365,7 +374,14 @@ describe('Evaluator', () => {
       totalShards: 10,
     };
 
-    const result = evaluator.evaluateFlag(flag, 'subject_key', { email: 'eppo@test.com' }, false);
+    const result = evaluator.evaluateFlag(
+      flag,
+      'subject_key',
+      { email: 'eppo@test.com' },
+      false,
+      '',
+      '',
+    );
     expect(result.flagKey).toEqual('obfuscated_flag_key');
     expect(result.allocationKey).toEqual('default');
     expect(result.variation).toEqual(VARIATION_A);
@@ -428,16 +444,16 @@ describe('Evaluator', () => {
       }),
     );
 
-    expect(deterministicEvaluator.evaluateFlag(flag, 'alice', {}, false).variation).toEqual(
+    expect(deterministicEvaluator.evaluateFlag(flag, 'alice', {}, false, '', '').variation).toEqual(
       VARIATION_A,
     );
-    expect(deterministicEvaluator.evaluateFlag(flag, 'bob', {}, false).variation).toEqual(
+    expect(deterministicEvaluator.evaluateFlag(flag, 'bob', {}, false, '', '').variation).toEqual(
       VARIATION_B,
     );
-    expect(deterministicEvaluator.evaluateFlag(flag, 'charlie', {}, false).variation).toEqual(
-      VARIATION_C,
-    );
-    expect(deterministicEvaluator.evaluateFlag(flag, 'dave', {}, false).variation).toEqual(
+    expect(
+      deterministicEvaluator.evaluateFlag(flag, 'charlie', {}, false, '', '').variation,
+    ).toEqual(VARIATION_C);
+    expect(deterministicEvaluator.evaluateFlag(flag, 'dave', {}, false, '', '').variation).toEqual(
       VARIATION_C,
     );
   });
@@ -468,7 +484,7 @@ describe('Evaluator', () => {
       totalShards: 10,
     };
 
-    const result = evaluator.evaluateFlag(flag, 'subject_key', {}, false);
+    const result = evaluator.evaluateFlag(flag, 'subject_key', {}, false, '', '');
     expect(result.flagKey).toEqual('flag');
     expect(result.allocationKey).toBeNull();
     expect(result.variation).toBeNull();
@@ -500,7 +516,7 @@ describe('Evaluator', () => {
       totalShards: 10,
     };
 
-    const result = evaluator.evaluateFlag(flag, 'subject_key', {}, false);
+    const result = evaluator.evaluateFlag(flag, 'subject_key', {}, false, '', '');
     expect(result.flagKey).toEqual('flag');
     expect(result.allocationKey).toEqual('default');
     expect(result.variation).toEqual(VARIATION_A);
@@ -532,7 +548,7 @@ describe('Evaluator', () => {
       totalShards: 10,
     };
 
-    const result = evaluator.evaluateFlag(flag, 'subject_key', {}, false);
+    const result = evaluator.evaluateFlag(flag, 'subject_key', {}, false, '', '');
     expect(result.flagKey).toEqual('flag');
     expect(result.allocationKey).toBeNull();
     expect(result.variation).toBeNull();

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -32,8 +32,14 @@ export class Evaluator {
     subjectKey: string,
     subjectAttributes: SubjectAttributes,
     obfuscated: boolean,
+    configFetchTime: string,
+    configPublishTime: string,
   ): FlagEvaluation {
-    const flagEvaluationDetailsBuilder = new FlagEvaluationDetailsBuilder(flag.allocations);
+    const flagEvaluationDetailsBuilder = new FlagEvaluationDetailsBuilder(
+      flag.allocations,
+      configFetchTime,
+      configPublishTime,
+    );
 
     if (!flag.enabled) {
       return noneResult(

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -32,13 +32,13 @@ export class Evaluator {
     subjectKey: string,
     subjectAttributes: SubjectAttributes,
     obfuscated: boolean,
-    configFetchTime: string,
-    configPublishTime: string,
+    configFetchedAt: string,
+    configPublishedAt: string,
   ): FlagEvaluation {
     const flagEvaluationDetailsBuilder = new FlagEvaluationDetailsBuilder(
       flag.allocations,
-      configFetchTime,
-      configPublishTime,
+      configFetchedAt,
+      configPublishedAt,
     );
 
     if (!flag.enabled) {

--- a/src/flag-configuration-requestor.ts
+++ b/src/flag-configuration-requestor.ts
@@ -16,8 +16,8 @@ export default class FlagConfigurationRequestor {
     }
     const didUpdateServingStore = await this.configurationStore.setEntries(responseData.flags);
     if (didUpdateServingStore) {
-      this.configurationStore.setConfigFetchTime(new Date().toISOString());
-      this.configurationStore.setConfigPublishTime(responseData.createdAt);
+      this.configurationStore.setConfigFetchedAt(new Date().toISOString());
+      this.configurationStore.setConfigPublishedAt(responseData.createdAt);
     }
     return responseData.flags;
   }

--- a/src/flag-configuration-requestor.ts
+++ b/src/flag-configuration-requestor.ts
@@ -14,7 +14,11 @@ export default class FlagConfigurationRequestor {
     if (!responseData) {
       return {};
     }
-    await this.configurationStore.setEntries(responseData.flags);
+    const didUpdateServingStore = await this.configurationStore.setEntries(responseData.flags);
+    if (didUpdateServingStore) {
+      this.configurationStore.setConfigFetchTime(new Date().toISOString());
+      this.configurationStore.setConfigPublishTime(responseData.createdAt);
+    }
     return responseData.flags;
   }
 }

--- a/src/flag-evaluation-details.ts
+++ b/src/flag-evaluation-details.ts
@@ -31,8 +31,8 @@ export interface FlagEvaluationDetails {
   variationValue: Variation['value'] | null;
   flagEvaluationCode: FlagEvaluationCode;
   flagEvaluationDescription: string;
-  configFetchTime: string;
-  configPublishTime: string;
+  configFetchedAt: string;
+  configPublishedAt: string;
   matchedRule: Rule | null;
   matchedAllocation: AllocationEvaluation | null;
   unmatchedAllocations: Array<AllocationEvaluation>;
@@ -49,8 +49,8 @@ export class FlagEvaluationDetailsBuilder {
 
   constructor(
     private readonly allocations: Allocation[],
-    private readonly configFetchTime: string,
-    private readonly configPublishTime: string,
+    private readonly configFetchedAt: string,
+    private readonly configPublishedAt: string,
   ) {
     this.setNone();
   }
@@ -125,8 +125,8 @@ export class FlagEvaluationDetailsBuilder {
     flagEvaluationDescription,
     variationKey: this.variationKey,
     variationValue: this.variationValue,
-    configFetchTime: this.configFetchTime,
-    configPublishTime: this.configPublishTime,
+    configFetchedAt: this.configFetchedAt,
+    configPublishedAt: this.configPublishedAt,
     matchedRule: this.matchedRule,
     matchedAllocation: this.matchedAllocation,
     unmatchedAllocations: this.unmatchedAllocations,

--- a/src/flag-evaluation-details.ts
+++ b/src/flag-evaluation-details.ts
@@ -31,6 +31,8 @@ export interface FlagEvaluationDetails {
   variationValue: Variation['value'] | null;
   flagEvaluationCode: FlagEvaluationCode;
   flagEvaluationDescription: string;
+  configFetchTime: string;
+  configPublishTime: string;
   matchedRule: Rule | null;
   matchedAllocation: AllocationEvaluation | null;
   unmatchedAllocations: Array<AllocationEvaluation>;
@@ -45,7 +47,11 @@ export class FlagEvaluationDetailsBuilder {
   private unmatchedAllocations: FlagEvaluationDetails['unmatchedAllocations'];
   private unevaluatedAllocations: FlagEvaluationDetails['unevaluatedAllocations'];
 
-  constructor(private readonly allocations: Allocation[]) {
+  constructor(
+    private readonly allocations: Allocation[],
+    private readonly configFetchTime: string,
+    private readonly configPublishTime: string,
+  ) {
     this.setNone();
   }
 
@@ -119,6 +125,8 @@ export class FlagEvaluationDetailsBuilder {
     flagEvaluationDescription,
     variationKey: this.variationKey,
     variationValue: this.variationValue,
+    configFetchTime: this.configFetchTime,
+    configPublishTime: this.configPublishTime,
     matchedRule: this.matchedRule,
     matchedAllocation: this.matchedAllocation,
     unmatchedAllocations: this.unmatchedAllocations,

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -17,6 +17,7 @@ export class HttpRequestError extends Error {
 }
 
 export interface IUniversalFlagConfig {
+  createdAt: string; // ISO formatted string
   flags: Record<string, Flag>;
 }
 

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -114,7 +114,11 @@ export function validateTestAssignmentDetails(
 ) {
   for (const { subject, assignmentDetails } of assignments) {
     try {
-      expect(subject.assignmentDetails).toEqual(assignmentDetails);
+      expect(assignmentDetails).toMatchObject({
+        ...subject.assignmentDetails,
+        configFetchTime: expect.any(String),
+        configPublishTime: expect.any(String),
+      });
     } catch (err) {
       err.message = `The assignment details for subject ${subject.subjectKey} did not match the expected value for flag ${flag}. ${err.message}`;
       throw err;

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -116,8 +116,8 @@ export function validateTestAssignmentDetails(
     try {
       expect(assignmentDetails).toMatchObject({
         ...subject.assignmentDetails,
-        configFetchTime: expect.any(String),
-        configPublishTime: expect.any(String),
+        configFetchedAt: expect.any(String),
+        configPublishedAt: expect.any(String),
       });
     } catch (err) {
       err.message = `The assignment details for subject ${subject.subjectKey} did not match the expected value for flag ${flag}. ${err.message}`;


### PR DESCRIPTION
[FF-2501](https://linear.app/eppo/issue/FF-2501)

js-client-sdk implements this functionality in https://github.com/Eppo-exp/js-client-sdk/pull/90

## Motivation and Context
Implements `configFetchTime` and `configPublishTime` to give users a better understanding of which version of the configuration is loaded.

## How has this been tested?
Integration testing
