### PR TITLE
Update for updated shared test data

### DIFF
--- a/src/client/eppo-client-with-bandits.spec.ts
+++ b/src/client/eppo-client-with-bandits.spec.ts
@@ -61,7 +61,7 @@ describe('EppoClient Bandits E2E test', () => {
   });
 
   beforeEach(() => {
-    client = new EppoClient(flagStore, undefined, false, banditFlagStore, banditModelStore);
+    client = new EppoClient(flagStore, banditFlagStore, banditModelStore, undefined, false);
     client.setIsGracefulFailureMode(false);
     client.setAssignmentLogger({ logAssignment: mockLogAssignment });
     client.setBanditLogger({ logBanditAction: mockLogBanditAction });

--- a/src/client/eppo-client-with-bandits.spec.ts
+++ b/src/client/eppo-client-with-bandits.spec.ts
@@ -90,8 +90,8 @@ describe('EppoClient Bandits E2E test', () => {
           });
 
           const subjectAttributes = {
-            ...subject.subjectAttributes.numeric_attributes,
-            ...subject.subjectAttributes.categorical_attributes,
+            ...subject.subjectAttributes.numericAttributes,
+            ...subject.subjectAttributes.categoricalAttributes,
           };
 
           const banditAssignment = client.getBanditAction(

--- a/src/client/eppo-client-with-bandits.spec.ts
+++ b/src/client/eppo-client-with-bandits.spec.ts
@@ -78,9 +78,6 @@ describe('EppoClient Bandits E2E test', () => {
         const { defaultValue, subjects } = testsByFlagKey[flagKey];
         let numAssignmentsChecked = 0;
         subjects.forEach((subject) => {
-          // TODO: handle already-bucketed attributes
-          // TODO: common test case with a numeric value passed as a categorical attribute and vice verse
-
           const actions: Record<string, Attributes> = {};
           subject.actions.forEach((action) => {
             actions[action.actionKey] = {
@@ -89,10 +86,22 @@ describe('EppoClient Bandits E2E test', () => {
             };
           });
 
-          const subjectAttributes = {
-            ...subject.subjectAttributes.numericAttributes,
-            ...subject.subjectAttributes.categoricalAttributes,
-          };
+          // TODO: handle already-bucketed attributes
+          const subjectAttributes: Attributes = {};
+          Object.entries(subject.subjectAttributes.numericAttributes).forEach(
+            ([attribute, value]) => {
+              if (typeof attribute === 'number') {
+                subjectAttributes[attribute] = value;
+              }
+            },
+          );
+          Object.entries(subject.subjectAttributes.categoricalAttributes).forEach(
+            ([attribute, value]) => {
+              if (value) {
+                subjectAttributes[attribute] = value.toString();
+              }
+            },
+          );
 
           const banditAssignment = client.getBanditAction(
             flagKey,

--- a/src/client/eppo-client-with-bandits.spec.ts
+++ b/src/client/eppo-client-with-bandits.spec.ts
@@ -13,14 +13,14 @@ import { IBanditEvent, IBanditLogger } from '../bandit-logger';
 import ConfigurationRequestor from '../configuration-requestor';
 import { MemoryOnlyConfigurationStore } from '../configuration-store/memory.store';
 import FetchHttpClient from '../http-client';
-import { BanditFlagAssociation, BanditParameters, Flag } from '../interfaces';
+import { BanditVariation, BanditParameters, Flag } from '../interfaces';
 import { Attributes } from '../types';
 
 import EppoClient from './eppo-client';
 
 describe('EppoClient Bandits E2E test', () => {
   const flagStore = new MemoryOnlyConfigurationStore<Flag>();
-  const banditFlagStore = new MemoryOnlyConfigurationStore<BanditFlagAssociation[]>();
+  const banditVariationStore = new MemoryOnlyConfigurationStore<BanditVariation[]>();
   const banditModelStore = new MemoryOnlyConfigurationStore<BanditParameters>();
   let client: EppoClient;
   const mockLogAssignment = jest.fn();
@@ -54,14 +54,14 @@ describe('EppoClient Bandits E2E test', () => {
     const configurationRequestor = new ConfigurationRequestor(
       httpClient,
       flagStore,
-      banditFlagStore,
+      banditVariationStore,
       banditModelStore,
     );
     await configurationRequestor.fetchAndStoreConfigurations();
   });
 
   beforeEach(() => {
-    client = new EppoClient(flagStore, banditFlagStore, banditModelStore, undefined, false);
+    client = new EppoClient(flagStore, banditVariationStore, banditModelStore, undefined, false);
     client.setIsGracefulFailureMode(false);
     client.setAssignmentLogger({ logAssignment: mockLogAssignment });
     client.setBanditLogger({ logBanditAction: mockLogBanditAction });

--- a/src/client/eppo-client-with-bandits.spec.ts
+++ b/src/client/eppo-client-with-bandits.spec.ts
@@ -13,14 +13,15 @@ import { IBanditEvent, IBanditLogger } from '../bandit-logger';
 import ConfigurationRequestor from '../configuration-requestor';
 import { MemoryOnlyConfigurationStore } from '../configuration-store/memory.store';
 import FetchHttpClient from '../http-client';
-import { BanditParameters, Flag } from '../interfaces';
+import { BanditFlagAssociation, BanditParameters, Flag } from '../interfaces';
 import { Attributes } from '../types';
 
 import EppoClient from './eppo-client';
 
 describe('EppoClient Bandits E2E test', () => {
   const flagStore = new MemoryOnlyConfigurationStore<Flag>();
-  const banditStore = new MemoryOnlyConfigurationStore<BanditParameters>();
+  const banditFlagStore = new MemoryOnlyConfigurationStore<BanditFlagAssociation[]>();
+  const banditModelStore = new MemoryOnlyConfigurationStore<BanditParameters>();
   let client: EppoClient;
   const mockLogAssignment = jest.fn();
   const mockLogBanditAction = jest.fn();
@@ -50,12 +51,17 @@ describe('EppoClient Bandits E2E test', () => {
       },
     });
     const httpClient = new FetchHttpClient(apiEndpoints, 1000);
-    const configurationRequestor = new ConfigurationRequestor(httpClient, flagStore, banditStore);
+    const configurationRequestor = new ConfigurationRequestor(
+      httpClient,
+      flagStore,
+      banditFlagStore,
+      banditModelStore,
+    );
     await configurationRequestor.fetchAndStoreConfigurations();
   });
 
   beforeEach(() => {
-    client = new EppoClient(flagStore, banditStore);
+    client = new EppoClient(flagStore, undefined, false, banditFlagStore, banditModelStore);
     client.setIsGracefulFailureMode(false);
     client.setAssignmentLogger({ logAssignment: mockLogAssignment });
     client.setBanditLogger({ logBanditAction: mockLogBanditAction });

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -33,7 +33,13 @@ export async function init(configurationStore: IConfigurationStore<Flag | Obfusc
     },
   });
   const httpClient = new FetchHttpClient(apiEndpoints, 1000);
-  const configurationRequestor = new ConfigurationRequestor(httpClient, configurationStore, null);
+  const configurationRequestor = new ConfigurationRequestor(
+    httpClient,
+    configurationStore,
+    // Leave bandit stores empty for this test
+    null,
+    null,
+  );
   await configurationRequestor.fetchAndStoreConfigurations();
 }
 
@@ -263,7 +269,7 @@ describe('EppoClient E2E test', () => {
     it.each(readTestData<IAssignmentTestCase>(ASSIGNMENT_TEST_DATA_DIR))(
       'test variation assignment splits',
       async ({ flag, variationType, defaultValue, subjects }: IAssignmentTestCase) => {
-        const client = new EppoClient(storage, undefined, undefined, true);
+        const client = new EppoClient(storage, undefined, true);
         client.setIsGracefulFailureMode(false);
 
         const typeAssignmentFunctions = {
@@ -616,7 +622,7 @@ describe('EppoClient E2E test', () => {
     });
 
     it('Fetches initial configuration with parameters in constructor', async () => {
-      client = new EppoClient(thisFlagStorage, undefined, requestConfiguration);
+      client = new EppoClient(thisFlagStorage, requestConfiguration);
       client.setIsGracefulFailureMode(false);
       // no configuration loaded
       let variation = client.getNumericAssignment(flagKey, subject, {}, 123.4);
@@ -647,7 +653,7 @@ describe('EppoClient E2E test', () => {
         }
       }
 
-      client = new EppoClient(new MockStore(), new MockStore(), requestConfiguration);
+      client = new EppoClient(new MockStore(), requestConfiguration);
       client.setIsGracefulFailureMode(false);
       // no configuration loaded
       let variation = client.getNumericAssignment(flagKey, subject, {}, 0.0);
@@ -689,7 +695,7 @@ describe('EppoClient E2E test', () => {
         ...requestConfiguration,
         pollAfterSuccessfulInitialization,
       };
-      client = new EppoClient(thisFlagStorage, undefined, requestConfiguration);
+      client = new EppoClient(thisFlagStorage, requestConfiguration);
       client.setIsGracefulFailureMode(false);
       // no configuration loaded
       let variation = client.getNumericAssignment(flagKey, subject, {}, 0.0);
@@ -754,7 +760,7 @@ describe('EppoClient E2E test', () => {
         throwOnFailedInitialization,
         pollAfterFailedInitialization,
       };
-      client = new EppoClient(thisFlagStorage, undefined, requestConfiguration);
+      client = new EppoClient(thisFlagStorage, requestConfiguration);
       client.setIsGracefulFailureMode(false);
       // no configuration loaded
       expect(client.getNumericAssignment(flagKey, subject, {}, 0.0)).toBe(0.0);

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -269,7 +269,7 @@ describe('EppoClient E2E test', () => {
     it.each(readTestData<IAssignmentTestCase>(ASSIGNMENT_TEST_DATA_DIR))(
       'test variation assignment splits',
       async ({ flag, variationType, defaultValue, subjects }: IAssignmentTestCase) => {
-        const client = new EppoClient(storage, undefined, true);
+        const client = new EppoClient(storage, undefined, undefined, undefined, true);
         client.setIsGracefulFailureMode(false);
 
         const typeAssignmentFunctions = {
@@ -622,7 +622,7 @@ describe('EppoClient E2E test', () => {
     });
 
     it('Fetches initial configuration with parameters in constructor', async () => {
-      client = new EppoClient(thisFlagStorage, requestConfiguration);
+      client = new EppoClient(thisFlagStorage, undefined, undefined, requestConfiguration);
       client.setIsGracefulFailureMode(false);
       // no configuration loaded
       let variation = client.getNumericAssignment(flagKey, subject, {}, 123.4);
@@ -653,7 +653,7 @@ describe('EppoClient E2E test', () => {
         }
       }
 
-      client = new EppoClient(new MockStore(), requestConfiguration);
+      client = new EppoClient(new MockStore(), undefined, undefined, requestConfiguration);
       client.setIsGracefulFailureMode(false);
       // no configuration loaded
       let variation = client.getNumericAssignment(flagKey, subject, {}, 0.0);
@@ -695,7 +695,7 @@ describe('EppoClient E2E test', () => {
         ...requestConfiguration,
         pollAfterSuccessfulInitialization,
       };
-      client = new EppoClient(thisFlagStorage, requestConfiguration);
+      client = new EppoClient(thisFlagStorage, undefined, undefined, requestConfiguration);
       client.setIsGracefulFailureMode(false);
       // no configuration loaded
       let variation = client.getNumericAssignment(flagKey, subject, {}, 0.0);
@@ -760,7 +760,7 @@ describe('EppoClient E2E test', () => {
         throwOnFailedInitialization,
         pollAfterFailedInitialization,
       };
-      client = new EppoClient(thisFlagStorage, requestConfiguration);
+      client = new EppoClient(thisFlagStorage, undefined, undefined, requestConfiguration);
       client.setIsGracefulFailureMode(false);
       // no configuration loaded
       expect(client.getNumericAssignment(flagKey, subject, {}, 0.0)).toBe(0.0);

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -205,11 +205,10 @@ export default class EppoClient implements IEppoClient {
 
   constructor(
     private flagConfigurationStore: IConfigurationStore<Flag | ObfuscatedFlag>,
-    private configurationRequestParameters?: FlagConfigurationRequestParameters,
-    private isObfuscated = false,
-    // Parameter order is for backwards compatibility, and thus related items are not grouped
     private banditFlagConfigurationStore?: IConfigurationStore<BanditFlagAssociation[]>,
     private banditModelConfigurationStore?: IConfigurationStore<BanditParameters>,
+    private configurationRequestParameters?: FlagConfigurationRequestParameters,
+    private isObfuscated = false,
   ) {}
 
   public setConfigurationRequestParameters(

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -393,15 +393,13 @@ export default class EppoClient implements IEppoClient {
     actions: Record<string, Attributes>, // TODO: ability to provide a set of actions with no context, or context broken out by numeric/categorical
     defaultValue: string,
   ): { variation: string; action: string | null } {
+    // TODO: store bandit flag information so that if no actions provided, we can quickly return with default value
     let variation = this.getStringAssignment(flagKey, subjectKey, subjectAttributes, defaultValue);
     let action: string | null = null;
     const banditKey = variation;
     try {
       const banditParameters = this.banditConfigurationStore?.get(banditKey);
-      if (banditParameters && !Object.keys(actions ?? {}).length) {
-        // If it's a bandit, but we have no actions, just return default value
-        variation = defaultValue;
-      } else if (banditParameters) {
+      if (banditParameters) {
         // For now, we use the shortcut of assuming if a variation value is the key of a known bandit, that is the bandit we want
         const banditModelData = banditParameters.modelData;
         const banditEvaluation = this.banditEvaluator.evaluateBandit(

--- a/src/configuration-requestor.spec.ts
+++ b/src/configuration-requestor.spec.ts
@@ -151,7 +151,7 @@ describe('ConfigurationRequestor', () => {
       expect(nikeBrandAffinityCoefficient.attributeKey).toBe('brand_affinity');
       expect(nikeBrandAffinityCoefficient.coefficient).toBe(1);
       expect(nikeBrandAffinityCoefficient.missingValueCoefficient).toBe(-0.1);
-      expect(nikeCoefficients.actionCategoricalCoefficients).toHaveLength(1);
+      expect(nikeCoefficients.actionCategoricalCoefficients).toHaveLength(2);
       const nikeLoyaltyTierCoefficient = nikeCoefficients.actionCategoricalCoefficients[0];
       expect(nikeLoyaltyTierCoefficient.attributeKey).toBe('loyalty_tier');
       expect(nikeLoyaltyTierCoefficient.missingValueCoefficient).toBe(0);

--- a/src/configuration-requestor.spec.ts
+++ b/src/configuration-requestor.spec.ts
@@ -10,11 +10,11 @@ import ConfigurationRequestor from './configuration-requestor';
 import { IConfigurationStore } from './configuration-store/configuration-store';
 import { MemoryOnlyConfigurationStore } from './configuration-store/memory.store';
 import FetchHttpClient, { IHttpClient } from './http-client';
-import { BanditFlagAssociation, BanditParameters, Flag } from './interfaces';
+import { BanditVariation, BanditParameters, Flag } from './interfaces';
 
 describe('ConfigurationRequestor', () => {
   let flagStore: IConfigurationStore<Flag>;
-  let banditFlagStore: IConfigurationStore<BanditFlagAssociation[]>;
+  let banditVariationStore: IConfigurationStore<BanditVariation[]>;
   let banditModelStore: IConfigurationStore<BanditParameters>;
   let httpClient: IHttpClient;
   let configurationRequestor: ConfigurationRequestor;
@@ -30,12 +30,12 @@ describe('ConfigurationRequestor', () => {
     });
     httpClient = new FetchHttpClient(apiEndpoints, 1000);
     flagStore = new MemoryOnlyConfigurationStore<Flag>();
-    banditFlagStore = new MemoryOnlyConfigurationStore<BanditFlagAssociation[]>();
+    banditVariationStore = new MemoryOnlyConfigurationStore<BanditVariation[]>();
     banditModelStore = new MemoryOnlyConfigurationStore<BanditParameters>();
     configurationRequestor = new ConfigurationRequestor(
       httpClient,
       flagStore,
-      banditFlagStore,
+      banditVariationStore,
       banditModelStore,
     );
   });

--- a/src/configuration-requestor.spec.ts
+++ b/src/configuration-requestor.spec.ts
@@ -10,11 +10,12 @@ import ConfigurationRequestor from './configuration-requestor';
 import { IConfigurationStore } from './configuration-store/configuration-store';
 import { MemoryOnlyConfigurationStore } from './configuration-store/memory.store';
 import FetchHttpClient, { IHttpClient } from './http-client';
-import { BanditParameters, Flag } from './interfaces';
+import { BanditFlagAssociation, BanditParameters, Flag } from './interfaces';
 
 describe('ConfigurationRequestor', () => {
   let flagStore: IConfigurationStore<Flag>;
-  let banditStore: IConfigurationStore<BanditParameters>;
+  let banditFlagStore: IConfigurationStore<BanditFlagAssociation[]>;
+  let banditModelStore: IConfigurationStore<BanditParameters>;
   let httpClient: IHttpClient;
   let configurationRequestor: ConfigurationRequestor;
 
@@ -29,8 +30,14 @@ describe('ConfigurationRequestor', () => {
     });
     httpClient = new FetchHttpClient(apiEndpoints, 1000);
     flagStore = new MemoryOnlyConfigurationStore<Flag>();
-    banditStore = new MemoryOnlyConfigurationStore<BanditParameters>();
-    configurationRequestor = new ConfigurationRequestor(httpClient, flagStore, banditStore);
+    banditFlagStore = new MemoryOnlyConfigurationStore<BanditFlagAssociation[]>();
+    banditModelStore = new MemoryOnlyConfigurationStore<BanditParameters>();
+    configurationRequestor = new ConfigurationRequestor(
+      httpClient,
+      flagStore,
+      banditFlagStore,
+      banditModelStore,
+    );
   });
 
   afterEach(() => {
@@ -97,7 +104,7 @@ describe('ConfigurationRequestor', () => {
         end: 10000,
       });
 
-      expect(banditStore.getKeys().length).toBe(0);
+      expect(banditModelStore.getKeys().length).toBe(0);
     });
   });
 
@@ -129,9 +136,9 @@ describe('ConfigurationRequestor', () => {
       expect(flagStore.get('banner_bandit_flag')).toBeDefined();
       expect(flagStore.get('cold_start_bandit')).toBeDefined();
 
-      expect(banditStore.getKeys().length).toBeGreaterThanOrEqual(2);
+      expect(banditModelStore.getKeys().length).toBeGreaterThanOrEqual(2);
 
-      const bannerBandit = banditStore.get('banner_bandit');
+      const bannerBandit = banditModelStore.get('banner_bandit');
       expect(bannerBandit?.banditKey).toBe('banner_bandit');
       expect(bannerBandit?.modelName).toBe('falcon');
       expect(bannerBandit?.modelVersion).toBe('v123');
@@ -180,7 +187,7 @@ describe('ConfigurationRequestor', () => {
         bannerCoefficients['adidas'].subjectCategoricalCoefficients[0].valueCoefficients['female'],
       ).toBe(0);
 
-      const coldStartBandit = banditStore.get('cold_start_bandit');
+      const coldStartBandit = banditModelStore.get('cold_start_bandit');
       expect(coldStartBandit?.banditKey).toBe('cold_start_bandit');
       expect(coldStartBandit?.modelName).toBe('falcon');
       expect(coldStartBandit?.modelVersion).toBe('cold start');
@@ -192,7 +199,7 @@ describe('ConfigurationRequestor', () => {
     });
 
     it('Will not fetch bandit parameters if there is no store', async () => {
-      configurationRequestor = new ConfigurationRequestor(httpClient, flagStore, null);
+      configurationRequestor = new ConfigurationRequestor(httpClient, flagStore, null, null);
       await configurationRequestor.fetchAndStoreConfigurations();
       expect(fetchSpy).toHaveBeenCalledTimes(1);
     });

--- a/src/configuration-requestor.ts
+++ b/src/configuration-requestor.ts
@@ -1,13 +1,16 @@
 import { IConfigurationStore } from './configuration-store/configuration-store';
 import { IHttpClient } from './http-client';
-import { BanditParameters, Flag } from './interfaces';
+import { BanditFlagAssociation, BanditParameters, Flag } from './interfaces';
 
 // Requests AND stores flag configurations
 export default class ConfigurationRequestor {
   constructor(
     private readonly httpClient: IHttpClient,
     private readonly flagConfigurationStore: IConfigurationStore<Flag>,
-    private readonly banditConfigurationStore: IConfigurationStore<BanditParameters> | null,
+    private readonly flagBanditConfigurationStore: IConfigurationStore<
+      BanditFlagAssociation[]
+    > | null,
+    private readonly banditModelConfigurationStore: IConfigurationStore<BanditParameters> | null,
   ) {}
 
   async fetchAndStoreConfigurations(): Promise<void> {
@@ -18,16 +21,40 @@ export default class ConfigurationRequestor {
 
     await this.flagConfigurationStore.setEntries(configResponse.flags);
     const flagsHaveBandits = Object.keys(configResponse.bandits ?? {}).length > 0;
-    const banditStoreProvided = !!this.banditConfigurationStore;
-    if (flagsHaveBandits && banditStoreProvided) {
+    const banditStoresProvided = Boolean(
+      this.flagBanditConfigurationStore && this.banditModelConfigurationStore,
+    );
+    if (flagsHaveBandits && banditStoresProvided) {
+      // Map bandit flag associations by flag key for quick lookup (instead of bandit key as provided by the UFC)
+      const banditFlagAssociations = this.indexBanditFlagAssociationsByFlagKey(
+        configResponse.bandits,
+      );
+      this.flagBanditConfigurationStore?.setEntries(banditFlagAssociations);
       // TODO: different polling intervals for bandit parameters
       const banditResponse = await this.httpClient.getBanditParameters();
       if (banditResponse?.bandits) {
-        if (!this.banditConfigurationStore) {
+        if (!this.banditModelConfigurationStore) {
           throw new Error('Bandit parameters fetched but no bandit configuration store provided');
         }
-        await this.banditConfigurationStore.setEntries(banditResponse.bandits);
+        await this.banditModelConfigurationStore.setEntries(banditResponse.bandits);
       }
     }
+  }
+
+  private indexBanditFlagAssociationsByFlagKey(
+    banditFlagAssociationsByBanditKey: Record<string, BanditFlagAssociation[]>,
+  ): Record<string, BanditFlagAssociation[]> {
+    const banditFlagAssociationsByFlagKey: Record<string, BanditFlagAssociation[]> = {};
+    Object.values(banditFlagAssociationsByBanditKey).forEach((banditFlags) => {
+      banditFlags.forEach((banditFlag) => {
+        let flagAssociations = banditFlagAssociationsByFlagKey[banditFlag.flagKey];
+        if (!flagAssociations) {
+          flagAssociations = [];
+          banditFlagAssociationsByFlagKey[banditFlag.flagKey] = flagAssociations;
+        }
+        flagAssociations.push(banditFlag);
+      });
+    });
+    return banditFlagAssociationsByFlagKey;
   }
 }

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -1,5 +1,5 @@
 import ApiEndpoints from './api-endpoints';
-import { BanditFlagAssociation, BanditParameters, Flag } from './interfaces';
+import { BanditVariation, BanditParameters, Flag } from './interfaces';
 
 export interface IQueryParams {
   apiKey: string;
@@ -18,7 +18,7 @@ export class HttpRequestError extends Error {
 
 export interface IUniversalFlagConfigResponse {
   flags: Record<string, Flag>;
-  bandits: Record<string, BanditFlagAssociation[]>;
+  bandits: Record<string, BanditVariation[]>;
 }
 
 export interface IBanditParametersResponse {

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -1,5 +1,5 @@
 import ApiEndpoints from './api-endpoints';
-import { BanditParameters, Flag } from './interfaces';
+import { BanditFlagAssociation, BanditParameters, Flag } from './interfaces';
 
 export interface IQueryParams {
   apiKey: string;
@@ -18,15 +18,7 @@ export class HttpRequestError extends Error {
 
 export interface IUniversalFlagConfigResponse {
   flags: Record<string, Flag>;
-  bandits: Record<
-    string,
-    {
-      key: string;
-      flagKey: string;
-      variationKey: string;
-      variationValue: string;
-    }
-  >;
+  bandits: Record<string, BanditFlagAssociation[]>;
 }
 
 export interface IBanditParametersResponse {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -81,7 +81,7 @@ export interface ObfuscatedShard {
   ranges: Range[];
 }
 
-export interface BanditFlagAssociation {
+export interface BanditVariation {
   key: string;
   flagKey: string;
   variationKey: string;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -81,6 +81,13 @@ export interface ObfuscatedShard {
   ranges: Range[];
 }
 
+export interface BanditFlagAssociation {
+  key: string;
+  flagKey: string;
+  variationKey: string;
+  variationValue: string;
+}
+
 export interface BanditParameters {
   banditKey: string;
   modelName: string;

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -32,7 +32,7 @@ export interface BanditTestCase {
 
 interface BanditTestCaseSubject {
   subjectKey: string;
-  subjectAttributes: { numeric_attributes: Attributes; categorical_attributes: Attributes };
+  subjectAttributes: { numericAttributes: Attributes; categoricalAttributes: Attributes };
   actions: BanditTestCaseAction[];
   assignment: { variation: string; action: string | null };
 }


### PR DESCRIPTION
_Eppo Internal:_
🎟️ **Ticket:** [FF-2519 - JS SDK - Update for updated shared bandit test cases](https://linear.app/eppo/issue/FF-2519/js-sdk-update-for-updated-shared-bandit-test-cases)

Update this repository to handle the updated formatting and updated shared bandit test cases ([`sdk-test-data` #36](https://github.com/Eppo-exp/sdk-test-data/pull/36)).

For the no-actions-provided one to work, we need another configuration store to keep track of which flags have active bandits.

Note: Automated tests are expected to fail now; they should pass once updated test data is merged.