### PR TITLE
Handle explicitly bucketed numeric and categorical attributes 

### DIFF
--- a/src/bandit-evaluator.spec.ts
+++ b/src/bandit-evaluator.spec.ts
@@ -4,7 +4,7 @@ import {
   BanditModelData,
   BanditNumericAttributeCoefficients,
 } from './interfaces';
-import { Attributes } from './types';
+import { Attributes, ContextAttributes } from './types';
 
 describe('BanditEvaluator', () => {
   const banditEvaluator = new BanditEvaluator();
@@ -20,8 +20,8 @@ describe('BanditEvaluator', () => {
       attributes: Attributes,
     ) => number;
     scoreActions: (
-      subjectAttributes: Attributes,
-      actions: Record<string, Attributes>,
+      subjectAttributes: ContextAttributes,
+      actions: Record<string, ContextAttributes>,
       banditModel: Pick<BanditModelData, 'coefficients' | 'defaultActionScore'>,
     ) => Record<string, number>;
     weighActions: (
@@ -207,11 +207,14 @@ describe('BanditEvaluator', () => {
     };
 
     it('scores each action', () => {
-      const subjectAttributes: Attributes = { age: 30, location: 'US' };
-      const actions: Record<string, Attributes> = {
-        action1: { price: 25, category: 'A' },
-        action2: { price: 50, category: 'B' },
-        action99: { price: 100, category: 'C' },
+      const subjectAttributes: ContextAttributes = {
+        numericAttributes: { age: 30 },
+        categoricalAttributes: { location: 'US' },
+      };
+      const actions: Record<string, ContextAttributes> = {
+        action1: { numericAttributes: { price: 25 }, categoricalAttributes: { category: 'A' } },
+        action2: { numericAttributes: { price: 50 }, categoricalAttributes: { category: 'B' } },
+        action99: { numericAttributes: { price: 100 }, categoricalAttributes: { category: 'C' } },
       };
       const actionScores = exposedEvaluator.scoreActions(subjectAttributes, actions, modelData);
       expect(Object.keys(actionScores)).toHaveLength(3);
@@ -317,10 +320,13 @@ describe('BanditEvaluator', () => {
   describe('evaluateBandit', () => {
     it('evaluates the bandit with action contexts', () => {
       const flagKey = 'test_flag';
-      const subjectAttributes = { age: 25, location: 'US' };
-      const actions: Record<string, Attributes> = {
-        action1: { price: 10, category: 'A' },
-        action2: { price: 20, category: 'B' },
+      const subjectAttributes: ContextAttributes = {
+        numericAttributes: { age: 25 },
+        categoricalAttributes: { location: 'US' },
+      };
+      const actions: Record<string, ContextAttributes> = {
+        action1: { numericAttributes: { price: 10 }, categoricalAttributes: { category: 'A' } },
+        action2: { numericAttributes: { price: 20 }, categoricalAttributes: { category: 'B' } },
       };
       const banditModel: BanditModelData = {
         gamma: 0.1,

--- a/src/bandit-evaluator.ts
+++ b/src/bandit-evaluator.ts
@@ -5,14 +5,14 @@ import {
   BanditNumericAttributeCoefficients,
 } from './interfaces';
 import { MD5Sharder, Sharder } from './sharders';
-import { Attributes } from './types';
+import { Attributes, ContextAttributes } from './types';
 
 export interface BanditEvaluation {
   flagKey: string;
   subjectKey: string;
-  subjectAttributes: Attributes;
+  subjectAttributes: ContextAttributes;
   actionKey: string;
-  actionAttributes: Attributes;
+  actionAttributes: ContextAttributes;
   actionScore: number;
   actionWeight: number;
   gamma: number;
@@ -26,8 +26,8 @@ export class BanditEvaluator {
   public evaluateBandit(
     flagKey: string,
     subjectKey: string,
-    subjectAttributes: Attributes,
-    actions: Record<string, Attributes>, // TODO: option to specify if action attributes are numeric or categorical
+    subjectAttributes: ContextAttributes,
+    actions: Record<string, ContextAttributes>,
     banditModel: BanditModelData,
   ): BanditEvaluation {
     const actionScores: Record<string, number> = this.scoreActions(
@@ -52,7 +52,7 @@ export class BanditEvaluator {
     return {
       flagKey,
       subjectKey,
-      subjectAttributes,
+      subjectAttributes: subjectAttributes,
       actionKey: selectedActionKey,
       actionAttributes: actions[selectedActionKey],
       actionScore: actionScores[selectedActionKey],
@@ -63,8 +63,8 @@ export class BanditEvaluator {
   }
 
   private scoreActions(
-    subjectAttributes: Attributes,
-    actions: Record<string, Attributes>,
+    subjectAttributes: ContextAttributes,
+    actions: Record<string, ContextAttributes>,
     banditModel: Pick<BanditModelData, 'coefficients' | 'defaultActionScore'>,
   ): Record<string, number> {
     const actionScores: Record<string, number> = {};
@@ -75,19 +75,19 @@ export class BanditEvaluator {
         score = coefficients.intercept;
         score += this.scoreNumericAttributes(
           coefficients.subjectNumericCoefficients,
-          subjectAttributes,
+          subjectAttributes.numericAttributes,
         );
         score += this.scoreCategoricalAttributes(
           coefficients.subjectCategoricalCoefficients,
-          subjectAttributes,
+          subjectAttributes.categoricalAttributes,
         );
         score += this.scoreNumericAttributes(
           coefficients.actionNumericCoefficients,
-          actionAttributes,
+          actionAttributes.numericAttributes,
         );
         score += this.scoreCategoricalAttributes(
           coefficients.actionCategoricalCoefficients,
-          actionAttributes,
+          actionAttributes.categoricalAttributes,
         );
       }
       actionScores[actionKey] = score;

--- a/src/bandit-evaluator.ts
+++ b/src/bandit-evaluator.ts
@@ -52,7 +52,7 @@ export class BanditEvaluator {
     return {
       flagKey,
       subjectKey,
-      subjectAttributes: subjectAttributes,
+      subjectAttributes,
       actionKey: selectedActionKey,
       actionAttributes: actions[selectedActionKey],
       actionScore: actionScores[selectedActionKey],

--- a/src/client/eppo-client-with-bandits.spec.ts
+++ b/src/client/eppo-client-with-bandits.spec.ts
@@ -247,5 +247,56 @@ describe('EppoClient Bandits E2E test', () => {
         ).toThrow();
       });
     });
+
+    describe('Flexible arguments for attributes', () => {
+      it('Can take non-contextual subject attributes', async () => {
+        // mirror test case in test-case-banner-bandit.dynamic-typing.json
+        const actions: Record<string, ContextAttributes> = {
+          nike: {
+            numericAttributes: { brand_affinity: -5 },
+            categoricalAttributes: { loyalty_tier: 'silver' },
+          },
+          adidas: {
+            numericAttributes: { brand_affinity: 1.0 },
+            categoricalAttributes: { loyalty_tier: 'bronze' },
+          },
+          reebok: {
+            numericAttributes: { brand_affinity: 20 },
+            categoricalAttributes: { loyalty_tier: 'gold' },
+          },
+        };
+
+        const subjectAttributesWithAreaCode: Attributes = {
+          age: 25,
+          mistake: 'oops',
+          country: 'USA',
+          gender_identity: 'female',
+          area_code: '303', // categorical area code
+        };
+
+        let banditAssignment = client.getBanditAction(
+          flagKey,
+          'henry',
+          subjectAttributesWithAreaCode,
+          actions,
+          'default',
+        );
+        expect(banditAssignment.action).toBe('adidas');
+        expect(banditAssignment.variation).toBe('banner_bandit');
+
+        // changing area code to a number should result in a different evaluation
+        subjectAttributesWithAreaCode.area_code = 303;
+
+        banditAssignment = client.getBanditAction(
+          flagKey,
+          'henry',
+          subjectAttributesWithAreaCode,
+          actions,
+          'default',
+        );
+        expect(banditAssignment.action).toBe('reebok');
+        expect(banditAssignment.variation).toBe('banner_bandit');
+      });
+    });
   });
 });

--- a/src/client/eppo-client-with-bandits.spec.ts
+++ b/src/client/eppo-client-with-bandits.spec.ts
@@ -79,7 +79,7 @@ describe('EppoClient Bandits E2E test', () => {
       const { flag: flagKey, defaultValue, subjects } = testCases[fileName];
       let numAssignmentsChecked = 0;
       subjects.forEach((subject) => {
-        // test files have actions as an array, convert to map
+        // test files have actions as an array, so we convert them to a map as expected by the client
         const actions: Record<string, ContextAttributes> = {};
         subject.actions.forEach((action) => {
           actions[action.actionKey] = {

--- a/src/client/eppo-client-with-bandits.spec.ts
+++ b/src/client/eppo-client-with-bandits.spec.ts
@@ -249,6 +249,7 @@ describe('EppoClient Bandits E2E test', () => {
     });
 
     describe('Flexible arguments for attributes', () => {
+      // Note these mirror the test cases in test-case-banner-bandit.dynamic-typing.json
       it('Can take non-contextual subject attributes', async () => {
         // mirror test case in test-case-banner-bandit.dynamic-typing.json
         const actions: Record<string, ContextAttributes> = {
@@ -298,5 +299,40 @@ describe('EppoClient Bandits E2E test', () => {
         expect(banditAssignment.variation).toBe('banner_bandit');
       });
     });
+
+    it('Can take non-contextual action attributes', async () => {
+      const actionsWithNonContextualAttributes: Record<string, Attributes> = {
+        nike: { brand_affinity: -1.7, loyalty_tier: 'silver', zip: '81427' },
+        adidas: { brand_affinity: 0.0, loyalty_tier: 'bronze' },
+        reebok: { brand_affinity: 15, loyalty_tier: 'gold' }, // TODO: tweak
+      };
+
+      let banditAssignment = client.getBanditAction(
+        flagKey,
+        'imogene',
+        subjectAttributes,
+        actionsWithNonContextualAttributes,
+        'default',
+      );
+      expect(banditAssignment.action).toBe('nike');
+      expect(banditAssignment.variation).toBe('banner_bandit');
+
+      // changing zip code to a number should result in a different evaluation
+      actionsWithNonContextualAttributes.nike.zip = 81427;
+
+      banditAssignment = client.getBanditAction(
+        flagKey,
+        'imogene',
+        subjectAttributes,
+        actionsWithNonContextualAttributes,
+        'default',
+      );
+      expect(banditAssignment.action).toBe('nike');
+      expect(banditAssignment.variation).toBe('banner_bandit');
+    });
+  });
+
+  it('Can take actions without any context', async () => {
+    // TODO
   });
 });

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -30,7 +30,14 @@ import {
 } from '../interfaces';
 import { getMD5Hash } from '../obfuscation';
 import initPoller, { IPoller } from '../poller';
-import { Attributes, AttributeType, ValueType } from '../types';
+import {
+  Attributes,
+  AttributeType,
+  BanditActions,
+  BanditSubjectAttributes,
+  ContextAttributes,
+  ValueType,
+} from '../types';
 import { validateNotBlank } from '../validation';
 import { LIB_VERSION } from '../version';
 
@@ -145,8 +152,8 @@ export interface IEppoClient {
   getBanditAction(
     flagKey: string,
     subjectKey: string,
-    subjectAttributes: Attributes,
-    actions: Record<string, Attributes>,
+    subjectAttributes: BanditSubjectAttributes,
+    actions: BanditActions,
     defaultValue: string,
   ): { variation: string; action: string | null };
 
@@ -403,8 +410,8 @@ export default class EppoClient implements IEppoClient {
   public getBanditAction(
     flagKey: string,
     subjectKey: string,
-    subjectAttributes: Attributes,
-    actions: Record<string, Attributes>, // TODO: ability to provide a set of actions with no context, or context broken out by numeric/categorical
+    subjectAttributes: BanditSubjectAttributes,
+    actions: BanditActions,
     defaultValue: string,
   ): { variation: string; action: string | null } {
     const defaultResult = { variation: defaultValue, action: null };
@@ -419,7 +426,15 @@ export default class EppoClient implements IEppoClient {
       }
 
       // Get the assigned variation for the flag with a possible bandit
-      variation = this.getStringAssignment(flagKey, subjectKey, subjectAttributes, defaultValue);
+      // Note for getting assignments, we don't care about context
+      const nonContextualSubjectAttributes =
+        this.ensureNonContextualSubjectAttributes(subjectAttributes);
+      variation = this.getStringAssignment(
+        flagKey,
+        subjectKey,
+        nonContextualSubjectAttributes,
+        defaultValue,
+      );
 
       // Check if the assigned variation is an active bandit
       // Note: the reason for non-bandit assignments include the subject being bucketed into a non-bandit variation or
@@ -437,11 +452,14 @@ export default class EppoClient implements IEppoClient {
         }
 
         const banditModelData = banditParameters.modelData;
+        const contextualSubjectAttributes =
+          this.ensureContextualSubjectAttributes(subjectAttributes);
+        const actionsWithContextualAttributes = this.ensureActionsWithContextualAttributes(actions);
         const banditEvaluation = this.banditEvaluator.evaluateBandit(
           flagKey,
           subjectKey,
-          subjectAttributes,
-          actions,
+          contextualSubjectAttributes,
+          actionsWithContextualAttributes,
           banditModelData,
         );
         action = banditEvaluation.actionKey;
@@ -455,11 +473,11 @@ export default class EppoClient implements IEppoClient {
           actionProbability: banditEvaluation.actionWeight,
           optimalityGap: banditEvaluation.optimalityGap,
           modelVersion: banditParameters.modelVersion,
-          // TODO: bucket these out ahead of time
-          subjectNumericAttributes: this.pruneValuesByType(subjectAttributes, true),
-          subjectCategoricalAttributes: this.pruneValuesByType(subjectAttributes, false),
-          actionNumericAttributes: this.pruneValuesByType(actions[action], true),
-          actionCategoricalAttributes: this.pruneValuesByType(actions[action], false),
+          subjectNumericAttributes: contextualSubjectAttributes.numericAttributes,
+          subjectCategoricalAttributes: contextualSubjectAttributes.categoricalAttributes,
+          actionNumericAttributes: actionsWithContextualAttributes[action].numericAttributes,
+          actionCategoricalAttributes:
+            actionsWithContextualAttributes[action].categoricalAttributes,
           metaData: this.buildLoggerMetadata(),
         };
         this.logBanditAction(banditEvent);
@@ -473,6 +491,83 @@ export default class EppoClient implements IEppoClient {
     }
 
     return { variation, action };
+  }
+
+  private ensureNonContextualSubjectAttributes(
+    subjectAttributes: BanditSubjectAttributes,
+  ): Attributes {
+    let result: Attributes;
+    if ('numericAttributes' in subjectAttributes && 'categoricalAttributes' in subjectAttributes) {
+      // Attributes are contextual
+      const contextualSubjectAttributes = subjectAttributes as ContextAttributes;
+      result = {
+        ...contextualSubjectAttributes.numericAttributes,
+        ...contextualSubjectAttributes.categoricalAttributes,
+      };
+    } else {
+      // Attributes are non-contextual
+      result = subjectAttributes;
+    }
+    return result;
+  }
+
+  private ensureContextualSubjectAttributes(
+    subjectAttributes: BanditSubjectAttributes,
+  ): ContextAttributes {
+    let result: ContextAttributes;
+    if ('numericAttributes' in subjectAttributes && 'categoricalAttributes' in subjectAttributes) {
+      // Attributes are contextual
+      result = subjectAttributes as ContextAttributes;
+    } else {
+      // Attributes are non-contextual
+      result = this.deduceAttributeContext(subjectAttributes);
+    }
+    return result;
+  }
+
+  private ensureActionsWithContextualAttributes(
+    actions: BanditActions,
+  ): Record<string, ContextAttributes> {
+    let result: Record<string, ContextAttributes> = {};
+    if (Array.isArray(actions)) {
+      // no context
+      actions.forEach((action) => {
+        result[action] = { numericAttributes: {}, categoricalAttributes: {} };
+      });
+    } else if (
+      !Object.values(actions).every(
+        (value) =>
+          typeof value === 'object' &&
+          value && // exclude null
+          'numericAttributes' in value &&
+          'categoricalAttributes' in value,
+      )
+    ) {
+      // Actions have non-contextual attributes; bucket based on number or not
+      Object.entries(actions).forEach(([action, attributes]) => {
+        result[action] = this.deduceAttributeContext(attributes);
+      });
+    } else {
+      // Actions already have contextual attributes
+      result = actions as Record<string, ContextAttributes>;
+    }
+    return result;
+  }
+
+  private deduceAttributeContext(attributes: Attributes): ContextAttributes {
+    const contextualAttributes: ContextAttributes = {
+      numericAttributes: {},
+      categoricalAttributes: {},
+    };
+    Object.entries(attributes).forEach(([attribute, value]) => {
+      const isNumeric = typeof value === 'number' && isFinite(value);
+      if (isNumeric) {
+        contextualAttributes.numericAttributes[attribute] = value;
+      } else {
+        contextualAttributes.categoricalAttributes[attribute] = value as AttributeType;
+      }
+    });
+    return contextualAttributes;
   }
 
   private logBanditAction(banditEvent: IBanditEvent): void {
@@ -489,18 +584,6 @@ export default class EppoClient implements IEppoClient {
     } catch (err) {
       logger.warn('Error encountered logging bandit action', err);
     }
-  }
-
-  // TODO: this method can be repurposed to bucket attributes once bandit signatures updated
-  private pruneValuesByType(attributes: Attributes, numeric: boolean): Attributes {
-    const result: Attributes = {};
-    Object.entries(attributes).forEach(([key, value]) => {
-      const isNumeric = typeof value === 'number' && isFinite(value);
-      if (isNumeric === numeric) {
-        result[key] = value;
-      }
-    });
-    return result;
   }
 
   private getAssignmentVariation(

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import ApiEndpoints from './api-endpoints';
 import { logger } from './application-logger';
 import { IAssignmentHooks } from './assignment-hooks';
 import { IAssignmentLogger, IAssignmentEvent } from './assignment-logger';
+import { IBanditLogger, IBanditEvent } from './bandit-logger';
 import {
   AbstractAssignmentCache,
   AssignmentCache,
@@ -35,6 +36,8 @@ export {
   IAssignmentHooks,
   IAssignmentLogger,
   IAssignmentEvent,
+  IBanditLogger,
+  IBanditEvent,
   EppoClient,
   IEppoClient,
   constants,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,11 +2,11 @@ export type ValueType = string | number | boolean | JSON;
 export type AttributeType = string | number | boolean;
 export type ConditionValueType = AttributeType | AttributeType[];
 export type Attributes = { [key: string]: AttributeType };
-export type BanditSubjectAttributes = Attributes | ContextAttributes;
 export type ContextAttributes = {
   numericAttributes: Attributes;
   categoricalAttributes: Attributes;
 };
+export type BanditSubjectAttributes = Attributes | ContextAttributes;
 export type BanditActions =
   | string[]
   | Record<string, Attributes>

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,3 +2,12 @@ export type ValueType = string | number | boolean | JSON;
 export type AttributeType = string | number | boolean;
 export type ConditionValueType = AttributeType | AttributeType[];
 export type Attributes = { [key: string]: AttributeType };
+export type BanditSubjectAttributes = Attributes | ContextAttributes;
+export type ContextAttributes = {
+  numericAttributes: Attributes;
+  categoricalAttributes: Attributes;
+};
+export type BanditActions =
+  | string[]
+  | Record<string, Attributes>
+  | Record<string, ContextAttributes>;

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -1,7 +1,8 @@
 import * as fs from 'fs';
 
-import { VariationType, AttributeType, Attributes } from '../src';
+import { VariationType, AttributeType } from '../src';
 import { IBanditParametersResponse, IUniversalFlagConfigResponse } from '../src/http-client';
+import { ContextAttributes } from '../src/types';
 
 export const TEST_DATA_DIR = './test/data/ufc/';
 export const ASSIGNMENT_TEST_DATA_DIR = TEST_DATA_DIR + 'tests/';
@@ -32,15 +33,13 @@ export interface BanditTestCase {
 
 interface BanditTestCaseSubject {
   subjectKey: string;
-  subjectAttributes: { numericAttributes: Attributes; categoricalAttributes: Attributes };
+  subjectAttributes: ContextAttributes;
   actions: BanditTestCaseAction[];
   assignment: { variation: string; action: string | null };
 }
 
-interface BanditTestCaseAction {
+interface BanditTestCaseAction extends ContextAttributes {
   actionKey: string;
-  numericAttributes: Attributes;
-  categoricalAttributes: Attributes;
 }
 
 export function readMockUFCResponse(

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -49,14 +49,22 @@ export function readMockUFCResponse(
   return JSON.parse(fs.readFileSync(TEST_DATA_DIR + filename, 'utf-8'));
 }
 
-export function readTestData<T>(testDirectory: string): T[] {
-  const testCases = fs
+export function testCasesByFileName<T>(testDirectory: string): Record<string, T> {
+  const testCasesWithFileName: Array<T & { fileName: string }> = fs
     .readdirSync(testDirectory)
-    .map((file) => JSON.parse(fs.readFileSync(testDirectory + file, 'utf8')));
-  if (!testCases.length) {
+    .map((fileName) => ({
+      ...JSON.parse(fs.readFileSync(testDirectory + fileName, 'utf8')),
+      fileName,
+    }));
+  if (!testCasesWithFileName.length) {
     throw new Error('No test cases at ' + testDirectory);
   }
-  return testCases;
+  const mappedTestCase: Record<string, T> = {};
+  testCasesWithFileName.forEach((testCaseWithFileName) => {
+    mappedTestCase[testCaseWithFileName.fileName] = testCaseWithFileName;
+  });
+
+  return mappedTestCase;
 }
 
 export function getTestAssignments(


### PR DESCRIPTION
_Eppo Internal:_
🎟️ **Ticket:** [FF-2511 - JS SDK - Support explicitly passed numeric/categorical attributes](https://linear.app/eppo/issue/FF-2511/js-sdk-support-explicitly-passed-numericcategorical-attributes)

## Motivation and Context
Sometimes, it may not be obvious if an attribute is numeric or categorical (e.g., area code, zip code, group number, etc.), so we provide the ability for clients to be specific about which attributes are numeric or categorical.

## Description

### New Types
In addition to the existing types:
```ts
export type AttributeType = string | number | boolean;
export type Attributes = { [key: string]: AttributeType };
```
We define some new types:
```ts
export type ContextAttributes = {
  numericAttributes: Attributes;
  categoricalAttributes: Attributes;
};
export type BanditSubjectAttributes = Attributes | ContextAttributes;
export type BanditActions =
  | string[]
  | Record<string, Attributes>
  | Record<string, ContextAttributes>;
```
The last two are what is passed to `getBanditAction()` for `subjectAttributes` and `actions` respectively, allowing flexibility for implementing engineers to do what is easiest and makes sense for their use case.

`BanditEvaluator`'s `evaluateBandit()` method has been modified to take the contextual versions of subject attributes (`ContextAttributes`) and actions (`Record<string, ContextAttributes>`).

### Helper Methods

The client's `getBanditAction()` has been modified with two helper functions to ensure that, regardless of what users provide, the evaluator gets the contextual versions:
* `ensureContextualSubjectAttributes()`
* `ensureActionsWithContextualAttributes()`

`getBanditAction()` also uses another helper method for its call to `getStringAssignment()` which, like other assignment getters, does not need context with the attributes:
* `ensureNonContextualSubjectAttributes()`

Combined, the above three helper methods safely allow full flexibility.

## How has this been tested?
* The existing shared test cases in `eppo-client.spec.ts` and `eppo-client-with-bandits.spec.ts`, which test the explicit bucketing cases
* Additional JavaScript-client-specific tests in `eppo-client-with-bandits.spec.ts` for when attributes are not explicitly bucketed

![image](https://github.com/Eppo-exp/js-client-sdk-common/assets/417605/2335171c-c21a-47d4-b440-0c106df30ca7)