### PR TITLE
FF-2526 removes `name` from `AllocationEvaluation`

### DIFF
--- a/src/assignment-logger.spec.ts
+++ b/src/assignment-logger.spec.ts
@@ -23,7 +23,6 @@ describe('IAssignmentEvent', () => {
         matchedRule: null,
         matchedAllocation: {
           key: 'allocation_123',
-          name: 'Allocation for allocation_123',
           allocationEvaluationCode: AllocationEvaluationCode.MATCH,
           orderPosition: 1,
         },

--- a/src/client/eppo-client-assignment-details.spec.ts
+++ b/src/client/eppo-client-assignment-details.spec.ts
@@ -77,7 +77,6 @@ describe('EppoClient get*AssignmentDetails', () => {
       },
       matchedAllocation: {
         key: 'targeted allocation',
-        name: 'Allocation for targeted allocation',
         allocationEvaluationCode: AllocationEvaluationCode.MATCH,
         orderPosition: 1,
       },
@@ -85,7 +84,6 @@ describe('EppoClient get*AssignmentDetails', () => {
       unevaluatedAllocations: [
         {
           key: '50/50 split',
-          name: 'Allocation for 50/50 split',
           allocationEvaluationCode: AllocationEvaluationCode.UNEVALUATED,
           orderPosition: 2,
         },
@@ -117,14 +115,12 @@ describe('EppoClient get*AssignmentDetails', () => {
       matchedRule: null,
       matchedAllocation: {
         key: '50/50 split',
-        name: 'Allocation for 50/50 split',
         allocationEvaluationCode: AllocationEvaluationCode.MATCH,
         orderPosition: 2,
       },
       unmatchedAllocations: [
         {
           key: 'targeted allocation',
-          name: 'Allocation for targeted allocation',
           allocationEvaluationCode: AllocationEvaluationCode.FAILING_RULE,
           orderPosition: 1,
         },
@@ -165,20 +161,17 @@ describe('EppoClient get*AssignmentDetails', () => {
       },
       matchedAllocation: {
         key: 'experiment',
-        name: 'Allocation for experiment',
         allocationEvaluationCode: AllocationEvaluationCode.MATCH,
         orderPosition: 3,
       },
       unmatchedAllocations: [
         {
           key: 'id rule',
-          name: 'Allocation for id rule',
           allocationEvaluationCode: AllocationEvaluationCode.FAILING_RULE,
           orderPosition: 1,
         },
         {
           key: 'internal users',
-          name: 'Allocation for internal users',
           allocationEvaluationCode: AllocationEvaluationCode.FAILING_RULE,
           orderPosition: 2,
         },
@@ -186,7 +179,6 @@ describe('EppoClient get*AssignmentDetails', () => {
       unevaluatedAllocations: [
         {
           key: 'rollout',
-          name: 'Allocation for rollout',
           allocationEvaluationCode: AllocationEvaluationCode.UNEVALUATED,
           orderPosition: 4,
         },

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -72,7 +72,6 @@ describe('EppoClient E2E test', () => {
     allocations: [
       {
         key: 'allocation-a',
-        name: 'Allocation for allocation-a',
         rules: [],
         splits: [
           {
@@ -460,7 +459,6 @@ describe('EppoClient E2E test', () => {
           allocations: [
             {
               key: 'allocation-a-2',
-              name: 'Allocation for allocation-a-2',
               rules: [],
               splits: [
                 {
@@ -481,7 +479,6 @@ describe('EppoClient E2E test', () => {
           allocations: [
             {
               key: 'allocation-a-3',
-              name: 'Allocation for allocation-a-3',
               rules: [],
               splits: [
                 {
@@ -514,7 +511,6 @@ describe('EppoClient E2E test', () => {
           allocations: [
             {
               key: 'allocation-a', // note: same key
-              name: 'Allocation for allocation-a',
               rules: [],
               splits: [
                 {
@@ -544,7 +540,6 @@ describe('EppoClient E2E test', () => {
           allocations: [
             {
               key: 'allocation-b', // note: different key
-              name: 'Allocation for allocation-b',
               rules: [],
               splits: [
                 {

--- a/src/decoding.spec.ts
+++ b/src/decoding.spec.ts
@@ -138,7 +138,6 @@ describe('decoding', () => {
     it('should correctly decode allocation without startAt and endAt', () => {
       const obfuscatedAllocation = {
         key: 'ZXhwZXJpbWVudA==',
-        name: 'QWxsb2NhdGlvbiBmb3IgZXhwZXJpbWVudA==',
         rules: [],
         splits: [], // tested in decodeSplit
         doLog: true,
@@ -146,7 +145,6 @@ describe('decoding', () => {
 
       const expectedAllocation = {
         key: 'experiment',
-        name: 'Allocation for experiment',
         rules: [],
         splits: [],
         doLog: true,
@@ -158,7 +156,6 @@ describe('decoding', () => {
     it('should correctly decode allocation with startAt and endAt', () => {
       const obfuscatedAllocation = {
         key: 'ZXhwZXJpbWVudA==',
-        name: 'QWxsb2NhdGlvbiBmb3IgZXhwZXJpbWVudA==',
         startAt: 'MjAyMC0wNC0wMVQxODo1ODo1NS44Mjla',
         endAt: 'MjAyNS0wNy0yOVQwOTowMDoxMy4yMDVa',
         rules: [],
@@ -168,7 +165,6 @@ describe('decoding', () => {
 
       const expectedAllocation = {
         key: 'experiment',
-        name: 'Allocation for experiment',
         rules: [],
         splits: [],
         doLog: true,

--- a/src/decoding.ts
+++ b/src/decoding.ts
@@ -48,7 +48,6 @@ export function decodeAllocation(allocation: ObfuscatedAllocation): Allocation {
   return {
     ...allocation,
     key: decodeBase64(allocation.key),
-    name: decodeBase64(allocation.name),
     splits: allocation.splits.map(decodeSplit),
     startAt: allocation.startAt
       ? new Date(decodeBase64(allocation.startAt)).toISOString()

--- a/src/evaluator.spec.ts
+++ b/src/evaluator.spec.ts
@@ -32,7 +32,6 @@ describe('Evaluator', () => {
       allocations: [
         {
           key: 'default',
-          name: 'Allocation for default',
           rules: [],
           splits: [
             {
@@ -114,7 +113,6 @@ describe('Evaluator', () => {
       allocations: [
         {
           key: 'allocation',
-          name: 'Allocation for allocation',
           rules: [],
           splits: [
             {
@@ -142,7 +140,6 @@ describe('Evaluator', () => {
       allocations: [
         {
           key: 'allocation',
-          name: 'Allocation for allocation',
           rules: [
             {
               conditions: [
@@ -182,7 +179,6 @@ describe('Evaluator', () => {
       allocations: [
         {
           key: 'allocation',
-          name: 'Allocation for allocation',
           rules: [
             {
               conditions: [
@@ -216,7 +212,6 @@ describe('Evaluator', () => {
       allocations: [
         {
           key: 'default',
-          name: 'Allocation for default',
           rules: [],
           splits: [
             {
@@ -247,7 +242,6 @@ describe('Evaluator', () => {
       allocations: [
         {
           key: 'first',
-          name: 'Allocation for first',
           rules: [
             {
               conditions: [
@@ -266,7 +260,6 @@ describe('Evaluator', () => {
         },
         {
           key: 'default',
-          name: 'Allocation for default',
           rules: [],
           splits: [
             {
@@ -302,7 +295,6 @@ describe('Evaluator', () => {
       allocations: [
         {
           key: 'first',
-          name: 'Allocation for first',
           rules: [
             {
               conditions: [
@@ -321,7 +313,6 @@ describe('Evaluator', () => {
         },
         {
           key: 'default',
-          name: 'Allocation for default',
           rules: [],
           splits: [
             {
@@ -357,7 +348,6 @@ describe('Evaluator', () => {
       allocations: [
         {
           key: 'first',
-          name: 'Allocation for first',
           rules: [
             {
               conditions: [
@@ -380,7 +370,6 @@ describe('Evaluator', () => {
         },
         {
           key: 'default',
-          name: 'Allocation for default',
           rules: [],
           splits: [
             {
@@ -416,7 +405,6 @@ describe('Evaluator', () => {
       allocations: [
         {
           key: 'first',
-          name: 'Allocation for first',
           splits: [
             {
               variationKey: 'a',
@@ -439,7 +427,6 @@ describe('Evaluator', () => {
         },
         {
           key: 'default',
-          name: 'Allocation for default',
           splits: [
             {
               variationKey: 'c',
@@ -490,7 +477,6 @@ describe('Evaluator', () => {
       allocations: [
         {
           key: 'default',
-          name: 'Allocation for default',
           startAt: new Date(now.getFullYear() + 1, 0, 1).toISOString(),
           endAt: new Date(now.getFullYear() + 1, 1, 1).toISOString(),
           rules: [],
@@ -523,7 +509,6 @@ describe('Evaluator', () => {
       allocations: [
         {
           key: 'default',
-          name: 'Allocation for default',
           startAt: new Date(now.getFullYear() - 1, 0, 1).toISOString(),
           endAt: new Date(now.getFullYear() + 1, 0, 1).toISOString(),
           rules: [],
@@ -556,7 +541,6 @@ describe('Evaluator', () => {
       allocations: [
         {
           key: 'default',
-          name: 'Allocation for default',
           startAt: new Date(now.getFullYear() - 2, 0, 1).toISOString(),
           endAt: new Date(now.getFullYear() - 1, 0, 1).toISOString(),
           rules: [],

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -70,7 +70,6 @@ export class Evaluator {
       const addUnmatchedAllocation = (code: AllocationEvaluationCode) => {
         unmatchedAllocations.push({
           key: allocation.key,
-          name: allocation.name,
           allocationEvaluationCode: code,
           orderPosition: i + 1,
         });

--- a/src/flag-evaluation-details-builder.ts
+++ b/src/flag-evaluation-details-builder.ts
@@ -22,7 +22,6 @@ export enum AllocationEvaluationCode {
 
 export interface AllocationEvaluation {
   key: string;
-  name: string;
   allocationEvaluationCode: AllocationEvaluationCode;
   orderPosition: number;
 }
@@ -67,7 +66,6 @@ export class FlagEvaluationDetailsBuilder {
     this.unevaluatedAllocations = this.allocations.map(
       (allocation, i): AllocationEvaluation => ({
         key: allocation.key,
-        name: allocation.name,
         allocationEvaluationCode: AllocationEvaluationCode.UNEVALUATED,
         orderPosition: i + 1,
       }),
@@ -105,7 +103,6 @@ export class FlagEvaluationDetailsBuilder {
     this.matchedRule = matchedRule;
     this.matchedAllocation = {
       key: allocation.key,
-      name: allocation.name,
       allocationEvaluationCode: AllocationEvaluationCode.MATCH,
       orderPosition: indexPosition + 1, // orderPosition is 1-indexed to match UI
     };
@@ -116,7 +113,6 @@ export class FlagEvaluationDetailsBuilder {
       (allocation, i) =>
         ({
           key: allocation.key,
-          name: allocation.name,
           allocationEvaluationCode: AllocationEvaluationCode.UNEVALUATED,
           orderPosition: unevaluatedStartOrderPosition + i,
         } as AllocationEvaluation),

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,7 +31,6 @@ export interface Split {
 
 export interface Allocation {
   key: string;
-  name: string;
   rules?: Rule[];
   startAt?: string; // ISO 8601
   endAt?: string; // ISO 8601
@@ -75,7 +74,6 @@ export interface ObfuscatedVariation {
 
 export interface ObfuscatedAllocation {
   key: string;
-  name: string;
   rules?: Rule[];
   startAt?: string; // ISO 8601
   endAt?: string; // ISO 8601

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
   "exclude": [
     "node_modules",
     "dist",
-    "src/**/*.spec.ts",
     "test/**/*"
   ]
 }


### PR DESCRIPTION
This removes support for `allocation.name` in the "Evaluation Reasons" feature to ensure that potentially sensitive data is not exposed.

Tests will pass after https://github.com/Eppo-exp/sdk-test-data/pull/43 is merged