### PR TITLE
export bandit types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/bandit-logger.ts
+++ b/src/bandit-logger.ts
@@ -17,5 +17,5 @@ export interface IBanditEvent {
 }
 
 export interface IBanditLogger {
-  logBanditAction(assignment: IBanditEvent): void;
+  logBanditAction(banditEvent: IBanditEvent): void;
 }

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -60,7 +60,7 @@ export interface IEppoClient {
   getStringAssignment(
     flagKey: string,
     subjectKey: string,
-    subjectAttributes: Record<string, AttributeType>,
+    subjectAttributes: Attributes,
     defaultValue: string,
   ): string;
 
@@ -70,7 +70,7 @@ export interface IEppoClient {
   getBoolAssignment(
     flagKey: string,
     subjectKey: string,
-    subjectAttributes: Record<string, AttributeType>,
+    subjectAttributes: Attributes,
     defaultValue: boolean,
   ): boolean;
 
@@ -86,7 +86,7 @@ export interface IEppoClient {
   getBooleanAssignment(
     flagKey: string,
     subjectKey: string,
-    subjectAttributes: Record<string, AttributeType>,
+    subjectAttributes: Attributes,
     defaultValue: boolean,
   ): boolean;
 
@@ -102,7 +102,7 @@ export interface IEppoClient {
   getIntegerAssignment(
     flagKey: string,
     subjectKey: string,
-    subjectAttributes: Record<string, AttributeType>,
+    subjectAttributes: Attributes,
     defaultValue: number,
   ): number;
 
@@ -118,7 +118,7 @@ export interface IEppoClient {
   getNumericAssignment(
     flagKey: string,
     subjectKey: string,
-    subjectAttributes: Record<string, AttributeType>,
+    subjectAttributes: Attributes,
     defaultValue: number,
   ): number;
 
@@ -134,7 +134,7 @@ export interface IEppoClient {
   getJSONAssignment(
     flagKey: string,
     subjectKey: string,
-    subjectAttributes: Record<string, AttributeType>,
+    subjectAttributes: Attributes,
     defaultValue: object,
   ): object;
 
@@ -328,7 +328,7 @@ export default class EppoClient implements IEppoClient {
   public getStringAssignment(
     flagKey: string,
     subjectKey: string,
-    subjectAttributes: Record<string, AttributeType>,
+    subjectAttributes: Attributes,
     defaultValue: string,
   ): string {
     return (
@@ -345,7 +345,7 @@ export default class EppoClient implements IEppoClient {
   public getBoolAssignment(
     flagKey: string,
     subjectKey: string,
-    subjectAttributes: Record<string, AttributeType>,
+    subjectAttributes: Attributes,
     defaultValue: boolean,
   ): boolean {
     return this.getBooleanAssignment(flagKey, subjectKey, subjectAttributes, defaultValue);
@@ -354,7 +354,7 @@ export default class EppoClient implements IEppoClient {
   public getBooleanAssignment(
     flagKey: string,
     subjectKey: string,
-    subjectAttributes: Record<string, AttributeType>,
+    subjectAttributes: Attributes,
     defaultValue: boolean,
   ): boolean {
     return (
@@ -371,7 +371,7 @@ export default class EppoClient implements IEppoClient {
   public getIntegerAssignment(
     flagKey: string,
     subjectKey: string,
-    subjectAttributes: Record<string, AttributeType>,
+    subjectAttributes: Attributes,
     defaultValue: number,
   ): number {
     return (
@@ -388,7 +388,7 @@ export default class EppoClient implements IEppoClient {
   public getNumericAssignment(
     flagKey: string,
     subjectKey: string,
-    subjectAttributes: Record<string, AttributeType>,
+    subjectAttributes: Attributes,
     defaultValue: number,
   ): number {
     return (
@@ -405,7 +405,7 @@ export default class EppoClient implements IEppoClient {
   public getJSONAssignment(
     flagKey: string,
     subjectKey: string,
-    subjectAttributes: Record<string, AttributeType>,
+    subjectAttributes: Attributes,
     defaultValue: object,
   ): object {
     return (
@@ -599,7 +599,7 @@ export default class EppoClient implements IEppoClient {
   private getAssignmentVariation(
     flagKey: string,
     subjectKey: string,
-    subjectAttributes: Record<string, AttributeType>,
+    subjectAttributes: Attributes,
     defaultValue: EppoValue,
     expectedVariationType: VariationType,
   ): EppoValue {
@@ -644,7 +644,7 @@ export default class EppoClient implements IEppoClient {
   public getAssignmentDetail(
     flagKey: string,
     subjectKey: string,
-    subjectAttributes: Record<string, AttributeType> = {},
+    subjectAttributes: Attributes = {},
     expectedVariationType?: VariationType,
   ): FlagEvaluation {
     validateNotBlank(subjectKey, 'Invalid argument: subjectKey cannot be blank');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import ApiEndpoints from './api-endpoints';
-import { logger } from './application-logger';
+import { logger as applicationLogger } from './application-logger';
 import { IAssignmentHooks } from './assignment-hooks';
 import { IAssignmentLogger, IAssignmentEvent } from './assignment-logger';
 import { IBanditLogger, IBanditEvent } from './bandit-logger';
@@ -27,11 +27,17 @@ import { MemoryStore, MemoryOnlyConfigurationStore } from './configuration-store
 import * as constants from './constants';
 import HttpClient from './http-client';
 import { Flag, ObfuscatedFlag, VariationType } from './interfaces';
-import { AttributeType, Attributes } from './types';
+import {
+  AttributeType,
+  Attributes,
+  BanditActions,
+  BanditSubjectAttributes,
+  ContextAttributes,
+} from './types';
 import * as validation from './validation';
 
 export {
-  logger as applicationLogger,
+  applicationLogger,
   AbstractAssignmentCache,
   IAssignmentHooks,
   IAssignmentLogger,
@@ -72,4 +78,7 @@ export {
   VariationType,
   AttributeType,
   Attributes,
+  ContextAttributes,
+  BanditSubjectAttributes,
+  BanditActions,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 export type ValueType = string | number | boolean | JSON;
 export type AttributeType = string | number | boolean;
 export type ConditionValueType = AttributeType | AttributeType[];
-export type Attributes = { [key: string]: AttributeType };
+export type Attributes = Record<string, AttributeType>;
 export type ContextAttributes = {
   numericAttributes: Attributes;
   categoricalAttributes: Attributes;


### PR DESCRIPTION
_Eppo Internal_:
🎟️ **Ticket:** [FF-2585 - Export common bandit logger types](https://linear.app/eppo/issue/FF-2584/node-sdk-export-common-bandit-logger-types)

It's useful for developers to have public access to the types used to define attributes, bandit attributes, and actions.