### PR TITLE
fix: incorrect evaluation details code returned for TYPE_MISMATCH

### DIFF
--- a/src/client/eppo-client-assignment-details.spec.ts
+++ b/src/client/eppo-client-assignment-details.spec.ts
@@ -235,6 +235,49 @@ describe('EppoClient get*AssignmentDetails', () => {
     } as IAssignmentDetails<number>);
   });
 
+  it('should handle type mismatches with graceful failure mode enabled', () => {
+    const client = new EppoClient(storage);
+    client.setIsGracefulFailureMode(true);
+    const result = client.getBooleanAssignmentDetails('integer-flag', 'alice', {}, true);
+    expect(result).toEqual({
+      variation: true,
+      action: null,
+      evaluationDetails: {
+        environmentName: 'Test',
+        flagEvaluationCode: 'TYPE_MISMATCH',
+        flagEvaluationDescription:
+          'Variation value does not have the correct type. Found INTEGER, but expected BOOLEAN for flag integer-flag',
+        variationKey: null,
+        variationValue: null,
+        banditKey: null,
+        banditAction: null,
+        configFetchedAt: expect.any(String),
+        configPublishedAt: expect.any(String),
+        matchedRule: null,
+        matchedAllocation: null,
+        unmatchedAllocations: [],
+        unevaluatedAllocations: [
+          {
+            key: 'targeted allocation',
+            allocationEvaluationCode: AllocationEvaluationCode.UNEVALUATED,
+            orderPosition: 1,
+          },
+          {
+            key: '50/50 split',
+            allocationEvaluationCode: AllocationEvaluationCode.UNEVALUATED,
+            orderPosition: 2,
+          },
+        ],
+      },
+    } as IAssignmentDetails<boolean>);
+  });
+
+  it('should throw an error for type mismatches with graceful failure mode disabled', () => {
+    const client = new EppoClient(storage);
+    client.setIsGracefulFailureMode(false);
+    expect(() => client.getBooleanAssignmentDetails('integer-flag', 'alice', {}, true)).toThrow();
+  });
+
   describe('UFC General Test Cases', () => {
     const testStart = Date.now();
 


### PR DESCRIPTION
See also: [sdk-test-data updates](https://github.com/Eppo-exp/sdk-test-data/pull/47). Tests will pass once that PR is merged.

Fixes: [FF-2846](https://linear.app/eppo/issue/FF-2846/jsnode-sdk-incorrect-assignment-type-returned-in-evaluation-details)

## Motivation and Context
(see ticket)
- If user specifies incorrect assignment type (e.g., boolean instead of string), ASSIGNMENT_ERROR is returned instead of expected TYPE_MISMATCH
- When there’s an (internal) error in configuration when flag.variationType does not match variation’s value, TYPE_MISMATCH is returned when ASSIGNMENT_ERROR is more fitting

## Description
Calling getIntegerAssignmentDetails for a non-numeric variation now returns a `flagEvaluationCode` of `TYPE_MISMATCH` instead of `ASSIGNMENT_ERROR`. A misconfigured variation now returns an `ASSIGNMENT_ERROR` instead `TYPE_MISMATCH`.

## How has this been tested?
With unit tests and manual testing by locally installing into a react app.
