### PR TITLE
Tie break top-scoring bandit actions by action name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/bandit-evaluator.ts
+++ b/src/bandit-evaluator.ts
@@ -144,7 +144,12 @@ export class BanditEvaluator {
     let currTopScore: number | null = null;
     let currTopAction: string | null = null;
     actionScoreEntries.forEach(([actionKey, actionScore]) => {
-      if (currTopScore === null || actionScore > currTopScore) {
+      if (
+        currTopScore === null ||
+        currTopAction === null ||
+        actionScore > currTopScore ||
+        (actionScore === currTopScore && actionKey < currTopAction)
+      ) {
         currTopScore = actionScore;
         currTopAction = actionKey;
       }


### PR DESCRIPTION
_Eppo Internal_
🎟️ **Ticket:** [FF-3004 - Tie break top scoring bandit actions by action name](https://linear.app/eppo/issue/FF-3004/js-common-sdk-tie-break-top-scoring-bandit-actions-by-action-name)

## Motivation and Context
There are certain situations where actions can be tied for the top score. In these situations, we want to deterministically declare a winner, as its weight is computed differently than the others. Currently, in this SDK, the winner is based on the order in which the actions are passed to the bandit--which is not what we want.

This situation is recreated in a newly added test case for our shared test data ([PR link](https://github.com/Eppo-exp/sdk-test-data/pull/52))

## Description
When determining the top-scoring action, prioritize actions with alphabetically earlier names.

## How has this been tested?
Will be tested by the new shared test case data. In the meantime, I manually copied the test files to run the test.