### PR TITLE
Add bandit assignment cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.0.2",
+  "version": "4.1.2",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.1.2",
+  "version": "4.1.0",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [

--- a/src/cache/abstract-assignment-cache.spec.ts
+++ b/src/cache/abstract-assignment-cache.spec.ts
@@ -5,7 +5,7 @@ import {
 } from './abstract-assignment-cache';
 
 describe('NonExpiringInMemoryAssignmentCache', () => {
-  it('read and write entries', () => {
+  it('read and write variation entries', () => {
     const cache = new NonExpiringInMemoryAssignmentCache();
     const key1 = { subjectKey: 'a', flagKey: 'b', allocationKey: 'c', variationKey: 'd' };
     const key2 = { subjectKey: '1', flagKey: '2', allocationKey: '3', variationKey: '4' };
@@ -14,7 +14,7 @@ describe('NonExpiringInMemoryAssignmentCache', () => {
     expect(cache.has(key2)).toBeFalsy();
     cache.set(key2);
     expect(cache.has(key2)).toBeTruthy();
-    // this makes an assumption about the internal implementation of the cache, which is not ideal
+    // this makes an assumption about the internal implementation of the cache, which is not ideal,
     // but it's the only way to test the cache without exposing the internal state
     expect(Array.from(cache.entries())).toEqual([
       [assignmentCacheKeyToString(key1), assignmentCacheValueToString(key1)],
@@ -23,5 +23,25 @@ describe('NonExpiringInMemoryAssignmentCache', () => {
 
     expect(cache.has({ ...key1, allocationKey: 'c1' })).toBeFalsy();
     expect(cache.has({ ...key2, variationKey: 'd1' })).toBeFalsy();
+  });
+
+  it('read and write bandit entries', () => {
+    const cache = new NonExpiringInMemoryAssignmentCache();
+    const key1 = { subjectKey: 'a', flagKey: 'b', banditKey: 'c', actionKey: 'd' };
+    const key2 = { subjectKey: '1', flagKey: '2', banditKey: '3', actionKey: '4' };
+    cache.set(key1);
+    expect(cache.has(key1)).toBeTruthy();
+    expect(cache.has(key2)).toBeFalsy();
+    cache.set(key2);
+    expect(cache.has(key2)).toBeTruthy();
+    // this makes an assumption about the internal implementation of the cache, which is not ideal,
+    // but it's the only way to test the cache without exposing the internal state
+    expect(Array.from(cache.entries())).toEqual([
+      [assignmentCacheKeyToString(key1), assignmentCacheValueToString(key1)],
+      [assignmentCacheKeyToString(key2), assignmentCacheValueToString(key2)],
+    ]);
+
+    expect(cache.has({ ...key1, banditKey: 'c1' })).toBeFalsy();
+    expect(cache.has({ ...key2, actionKey: 'd1' })).toBeFalsy();
   });
 });

--- a/src/cache/abstract-assignment-cache.ts
+++ b/src/cache/abstract-assignment-cache.ts
@@ -13,7 +13,15 @@ export type AssignmentCacheKey = {
   flagKey: string;
 };
 
-export type AssignmentCacheValue = Record<string, string>;
+export type CacheKeyPair<T extends string, U extends string> = {
+  [K in T]: string;
+} & {
+  [K in U]: string;
+};
+
+type VariationCacheValue = CacheKeyPair<'allocationKey', 'variationKey'>;
+type BanditCacheValue = CacheKeyPair<'banditKey', 'actionKey'>;
+export type AssignmentCacheValue = VariationCacheValue | BanditCacheValue;
 
 export type AssignmentCacheEntry = AssignmentCacheKey & AssignmentCacheValue;
 

--- a/src/cache/abstract-assignment-cache.ts
+++ b/src/cache/abstract-assignment-cache.ts
@@ -26,18 +26,8 @@ export function assignmentCacheKeyToString({ subjectKey, flagKey }: AssignmentCa
   return getMD5Hash([subjectKey, flagKey].join(';'));
 }
 
-export function assignmentCacheValueToString(cacheValue: AssignmentCacheValue): string {
-  const fieldsToHash: string[] = [];
-
-  if ('allocationKey' in cacheValue && 'variationKey' in cacheValue) {
-    fieldsToHash.push(cacheValue.allocationKey, cacheValue.variationKey);
-  }
-
-  if ('banditKey' in cacheValue && 'actionKey' in cacheValue) {
-    fieldsToHash.push(cacheValue.banditKey, cacheValue.actionKey);
-  }
-
-  return getMD5Hash(fieldsToHash.join(';'));
+export function assignmentCacheValueToString(cacheValue: Record<string, string>): string {
+  return getMD5Hash(Object.values(cacheValue).join(';'));
 }
 
 export interface AsyncMap<K, V> {

--- a/src/cache/abstract-assignment-cache.ts
+++ b/src/cache/abstract-assignment-cache.ts
@@ -2,22 +2,18 @@ import { getMD5Hash } from '../obfuscation';
 
 import { LRUCache } from './lru-cache';
 
-type FlagAssignmentCacheValue = {
-  allocationKey: string;
-  variationKey: string;
-};
-
-type BanditAssignmentCacheValue = {
-  banditKey: string;
-  actionKey: string;
-};
-
-export type AssignmentCacheValue = FlagAssignmentCacheValue | BanditAssignmentCacheValue;
-
+/**
+ * Assignment cache keys are only on the subject and flag level, while the entire value is used
+ * for uniqueness checking. This way that if an assigned variation or bandit action changes for a
+ * flag, it evicts the old one. Then, if an older assignment is later reassigned, it will be treated
+ * as new.
+ */
 export type AssignmentCacheKey = {
   subjectKey: string;
   flagKey: string;
 };
+
+export type AssignmentCacheValue = Record<string, string>;
 
 export type AssignmentCacheEntry = AssignmentCacheKey & AssignmentCacheValue;
 
@@ -26,7 +22,8 @@ export function assignmentCacheKeyToString({ subjectKey, flagKey }: AssignmentCa
   return getMD5Hash([subjectKey, flagKey].join(';'));
 }
 
-export function assignmentCacheValueToString(cacheValue: Record<string, string>): string {
+/** Converts an {@link AssignmentCacheValue} to a string. */
+export function assignmentCacheValueToString(cacheValue: AssignmentCacheValue): string {
   return getMD5Hash(Object.values(cacheValue).join(';'));
 }
 

--- a/src/cache/abstract-assignment-cache.ts
+++ b/src/cache/abstract-assignment-cache.ts
@@ -2,17 +2,17 @@ import { getMD5Hash } from '../obfuscation';
 
 import { LRUCache } from './lru-cache';
 
-export type FlagAssignmentCacheValue = {
+type FlagAssignmentCacheValue = {
   allocationKey: string;
   variationKey: string;
 };
 
-export type BanditAssignmentCacheValue = {
+type BanditAssignmentCacheValue = {
   banditKey: string;
   actionKey: string;
 };
 
-type AssignmentCacheValue = FlagAssignmentCacheValue | BanditAssignmentCacheValue;
+export type AssignmentCacheValue = FlagAssignmentCacheValue | BanditAssignmentCacheValue;
 
 export type AssignmentCacheKey = {
   subjectKey: string;

--- a/src/cache/abstract-assignment-cache.ts
+++ b/src/cache/abstract-assignment-cache.ts
@@ -2,10 +2,17 @@ import { getMD5Hash } from '../obfuscation';
 
 import { LRUCache } from './lru-cache';
 
-export type AssignmentCacheValue = {
+export type FlagAssignmentCacheValue = {
   allocationKey: string;
   variationKey: string;
 };
+
+export type BanditAssignmentCacheValue = {
+  banditKey: string;
+  actionKey: string;
+};
+
+type AssignmentCacheValue = FlagAssignmentCacheValue | BanditAssignmentCacheValue;
 
 export type AssignmentCacheKey = {
   subjectKey: string;
@@ -19,11 +26,18 @@ export function assignmentCacheKeyToString({ subjectKey, flagKey }: AssignmentCa
   return getMD5Hash([subjectKey, flagKey].join(';'));
 }
 
-export function assignmentCacheValueToString({
-  allocationKey,
-  variationKey,
-}: AssignmentCacheValue): string {
-  return getMD5Hash([allocationKey, variationKey].join(';'));
+export function assignmentCacheValueToString(cacheValue: AssignmentCacheValue): string {
+  const fieldsToHash: string[] = [];
+
+  if ('allocationKey' in cacheValue && 'variationKey' in cacheValue) {
+    fieldsToHash.push(cacheValue.allocationKey, cacheValue.variationKey);
+  }
+
+  if ('banditKey' in cacheValue && 'actionKey' in cacheValue) {
+    fieldsToHash.push(cacheValue.banditKey, cacheValue.actionKey);
+  }
+
+  return getMD5Hash(fieldsToHash.join(';'));
 }
 
 export interface AsyncMap<K, V> {

--- a/src/client/eppo-client-with-bandits.spec.ts
+++ b/src/client/eppo-client-with-bandits.spec.ts
@@ -440,7 +440,13 @@ describe('EppoClient Bandits E2E test', () => {
 
       // Convenience method for repeatedly making the exact same assignment call
       function requestClientBanditAction(): Omit<IAssignmentDetails<string>, 'evaluationDetails'> {
-        return client.getBanditAction(flagKey, subjectKey, subjectAttributes, ['toyota', 'honda'], 'control');
+        return client.getBanditAction(
+          flagKey,
+          subjectKey,
+          subjectAttributes,
+          ['toyota', 'honda'],
+          'control',
+        );
       }
 
       beforeAll(() => {

--- a/src/client/eppo-client-with-bandits.spec.ts
+++ b/src/client/eppo-client-with-bandits.spec.ts
@@ -434,6 +434,7 @@ describe('EppoClient Bandits E2E test', () => {
     describe('Assignment logging deduplication', () => {
       let mockEvaluateFlag: jest.SpyInstance;
       let mockEvaluateBandit: jest.SpyInstance;
+      // The below two variables allow easily changing what the mock evaluation functions return throughout the test
       let variationToReturn: string;
       let actionToReturn: string | null;
 
@@ -485,6 +486,7 @@ describe('EppoClient Bandits E2E test', () => {
 
       afterEach(() => {
         client.disableAssignmentCache();
+        client.disableBanditAssignmentCache();
       });
 
       afterAll(() => {
@@ -500,8 +502,8 @@ describe('EppoClient Bandits E2E test', () => {
 
         expect(firstNonBanditAssignment.variation).toBe('non-bandit');
         expect(firstNonBanditAssignment.action).toBeNull();
-        expect(mockLogAssignment).toHaveBeenCalledTimes(1);
-        expect(mockLogBanditAction).not.toHaveBeenCalled();
+        expect(mockLogAssignment).toHaveBeenCalledTimes(1); // new variation assignment
+        expect(mockLogBanditAction).not.toHaveBeenCalled(); // no bandit assignment
 
         // Assign bandit action
         variationToReturn = 'banner_bandit';
@@ -510,8 +512,8 @@ describe('EppoClient Bandits E2E test', () => {
 
         expect(firstBanditAssignment.variation).toBe('banner_bandit');
         expect(firstBanditAssignment.action).toBe('toyota');
-        expect(mockLogAssignment).toHaveBeenCalledTimes(2);
-        expect(mockLogBanditAction).toHaveBeenCalledTimes(1);
+        expect(mockLogAssignment).toHaveBeenCalledTimes(2); // new variation assignment
+        expect(mockLogBanditAction).toHaveBeenCalledTimes(1); // new bandit assignment
 
         // Repeat bandit action assignment
         variationToReturn = 'banner_bandit';
@@ -520,8 +522,8 @@ describe('EppoClient Bandits E2E test', () => {
 
         expect(secondBanditAssignment.variation).toBe('banner_bandit');
         expect(secondBanditAssignment.action).toBe('toyota');
-        expect(mockLogAssignment).toHaveBeenCalledTimes(2);
-        expect(mockLogBanditAction).toHaveBeenCalledTimes(1);
+        expect(mockLogAssignment).toHaveBeenCalledTimes(2); // repeat variation assignment
+        expect(mockLogBanditAction).toHaveBeenCalledTimes(1); // repeat bandit assignment
 
         // New bandit action assignment
         variationToReturn = 'banner_bandit';
@@ -530,8 +532,8 @@ describe('EppoClient Bandits E2E test', () => {
 
         expect(thirdBanditAssignment.variation).toBe('banner_bandit');
         expect(thirdBanditAssignment.action).toBe('honda');
-        expect(mockLogAssignment).toHaveBeenCalledTimes(2);
-        expect(mockLogBanditAction).toHaveBeenCalledTimes(2);
+        expect(mockLogAssignment).toHaveBeenCalledTimes(2); // repeat variation assignment
+        expect(mockLogBanditAction).toHaveBeenCalledTimes(2); // new bandit assignment
 
         // Flip-flop to an earlier action assignment
         variationToReturn = 'banner_bandit';
@@ -540,8 +542,8 @@ describe('EppoClient Bandits E2E test', () => {
 
         expect(fourthBanditAssignment.variation).toBe('banner_bandit');
         expect(fourthBanditAssignment.action).toBe('toyota');
-        expect(mockLogAssignment).toHaveBeenCalledTimes(2);
-        expect(mockLogBanditAction).toHaveBeenCalledTimes(3);
+        expect(mockLogAssignment).toHaveBeenCalledTimes(2); // repeat variation assignment
+        expect(mockLogBanditAction).toHaveBeenCalledTimes(3); // "new" bandit assignment
 
         // Flip-flop back to non-bandit assignment
         variationToReturn = 'non-bandit';
@@ -550,8 +552,8 @@ describe('EppoClient Bandits E2E test', () => {
 
         expect(secondNonBanditAssignment.variation).toBe('non-bandit');
         expect(secondNonBanditAssignment.action).toBeNull();
-        expect(mockLogAssignment).toHaveBeenCalledTimes(3);
-        expect(mockLogBanditAction).toHaveBeenCalledTimes(3);
+        expect(mockLogAssignment).toHaveBeenCalledTimes(3); // "new" variation assignment
+        expect(mockLogBanditAction).toHaveBeenCalledTimes(3); // no bandit assignment
       });
     });
   });

--- a/src/client/eppo-client-with-bandits.spec.ts
+++ b/src/client/eppo-client-with-bandits.spec.ts
@@ -205,6 +205,8 @@ describe('EppoClient Bandits E2E test', () => {
     });
 
     it('Flushed queued logging events when a logger is set', () => {
+      client.useLRUInMemoryAssignmentCache(5);
+      client.useLRUInMemoryBanditAssignmentCache(5);
       client.setAssignmentLogger(null as unknown as IAssignmentLogger);
       client.setBanditLogger(null as unknown as IBanditLogger);
       const banditAssignment = client.getBanditAction(
@@ -217,6 +219,20 @@ describe('EppoClient Bandits E2E test', () => {
 
       expect(banditAssignment.variation).toBe('banner_bandit');
       expect(banditAssignment.action).toBe('adidas');
+
+      expect(mockLogAssignment).not.toHaveBeenCalled();
+      expect(mockLogBanditAction).not.toHaveBeenCalled();
+
+      const repeatAssignment = client.getBanditAction(
+        flagKey,
+        subjectKey,
+        subjectAttributes,
+        actions,
+        'control',
+      );
+
+      expect(repeatAssignment.variation).toBe('banner_bandit');
+      expect(repeatAssignment.action).toBe('adidas');
 
       expect(mockLogAssignment).not.toHaveBeenCalled();
       expect(mockLogBanditAction).not.toHaveBeenCalled();

--- a/src/client/eppo-client-with-bandits.spec.ts
+++ b/src/client/eppo-client-with-bandits.spec.ts
@@ -480,6 +480,7 @@ describe('EppoClient Bandits E2E test', () => {
 
       beforeEach(() => {
         client.useNonExpiringInMemoryAssignmentCache();
+        client.useNonExpiringInMemoryBanditAssignmentCache();
       });
 
       afterEach(() => {
@@ -538,7 +539,7 @@ describe('EppoClient Bandits E2E test', () => {
         const fourthBanditAssignment = requestClientBanditAction();
 
         expect(fourthBanditAssignment.variation).toBe('banner_bandit');
-        expect(thirdBanditAssignment.action).toBe('toyota');
+        expect(fourthBanditAssignment.action).toBe('toyota');
         expect(mockLogAssignment).toHaveBeenCalledTimes(2);
         expect(mockLogBanditAction).toHaveBeenCalledTimes(3);
 

--- a/src/client/eppo-client.ts
+++ b/src/client/eppo-client.ts
@@ -659,7 +659,9 @@ export default class EppoClient {
 
     // What our bandit assignment cache cares about for avoiding logging duplicate bandit assignments,
     // if one is active. Like the flag assignment cache, entries are only stored for a given flag
-    // and subject.
+    // and subject. However, Bandit and action keys are also used for determining assignment uniqueness.
+    // This means that if a flag's bandit assigns one action, and then later a new action, the first
+    // one will be evicted from the cache. If later assigned again, it will be treated as new.
     const banditAssignmentCacheProperties = {
       flagKey,
       subjectKey,
@@ -668,6 +670,7 @@ export default class EppoClient {
     };
 
     if (this.banditAssignmentCache?.has(banditAssignmentCacheProperties)) {
+      // Ignore repeat assignment
       return;
     }
 
@@ -678,7 +681,7 @@ export default class EppoClient {
       }
       return;
     }
-    // If here, we have a logger
+    // If here, we have a logger and a new assignment to be logged
     try {
       this.banditLogger.logBanditAction(banditEvent);
       this.banditAssignmentCache?.set(banditAssignmentCacheProperties);


### PR DESCRIPTION
_Eppo Internal:_
🎟️ **Ticket:** [FF-3112 - JS Common SDK - Assignment cache should work at the bandit action level](https://linear.app/eppo/issue/FF-3112/js-common-sdk-assignment-cache-should-work-at-the-bandit-action-level)
🗨️ **Slack:** ["...are subsequent calls of the SDK assignment function still sending those events to the logger..."](https://eppo-group.slack.com/archives/C07GZEQA6GH/p1724359798605419)

## Motivation and Context
Customers may optionally want to exclude repeat bandit assignments from executing the logger callback to reduce the number of entries sent to their data warehouse.

## Description
This PR mirrors the flag assignment cache functionality for bandit actions. The difference is that the unique and cached value is a function of the bandit key and action key instead of the allocation key and variation key. The use of the flag key and subject key remains the same. 

Bandit action caching can be independently toggled from flag assignment caching. This could be useful when one wants action assignment caching but not bandit action caching, such as when using bandits to display ads and knowing when every impression was useful.

Caching happens at the subject and flag key levels for both--i.e. if a flag results in one action being assigned and then another, the first assignment is evicted from the cache to record the second. This allows for treating changed assignments as new, even if previously assigned.

## How has this been tested?
* Newly added `Assignment logging deduplication` test case to `eppo-client-with-bandits.spec.ts`