### PR TITLE
feat: getExperimentContainer helper function for CMS app integration

### DIFF
--- a/src/client/eppo-client-assignment-details.spec.ts
+++ b/src/client/eppo-client-assignment-details.spec.ts
@@ -5,35 +5,13 @@ import {
   MOCK_UFC_RESPONSE_FILE,
   readMockUFCResponse,
 } from '../../test/testHelpers';
-import ApiEndpoints from '../api-endpoints';
-import ConfigurationRequestor from '../configuration-requestor';
-import { IConfigurationStore } from '../configuration-store/configuration-store';
 import { MemoryOnlyConfigurationStore } from '../configuration-store/memory.store';
 import { AllocationEvaluationCode } from '../flag-evaluation-details-builder';
-import FetchHttpClient from '../http-client';
 import { Flag, ObfuscatedFlag, Variation, VariationType } from '../interfaces';
 import { OperatorType } from '../rules';
 
 import EppoClient, { IAssignmentDetails } from './eppo-client';
-
-async function init(configurationStore: IConfigurationStore<Flag | ObfuscatedFlag>) {
-  const apiEndpoints = new ApiEndpoints({
-    baseUrl: 'http://127.0.0.1:4000',
-    queryParams: {
-      apiKey: 'dummy',
-      sdkName: 'js-client-sdk-common',
-      sdkVersion: '1.0.0',
-    },
-  });
-  const httpClient = new FetchHttpClient(apiEndpoints, 1000);
-  const configurationRequestor = new ConfigurationRequestor(
-    httpClient,
-    configurationStore,
-    null,
-    null,
-  );
-  await configurationRequestor.fetchAndStoreConfigurations();
-}
+import { initConfiguration } from './test-utils';
 
 describe('EppoClient get*AssignmentDetails', () => {
   const testStart = Date.now();
@@ -50,7 +28,7 @@ describe('EppoClient get*AssignmentDetails', () => {
   const storage = new MemoryOnlyConfigurationStore<Flag | ObfuscatedFlag>();
 
   beforeAll(async () => {
-    await init(storage);
+    await initConfiguration(storage);
   });
 
   it('should set the details for a matched rule', () => {
@@ -307,7 +285,7 @@ describe('EppoClient get*AssignmentDetails', () => {
         });
       }) as jest.Mock;
 
-      await init(storage);
+      await initConfiguration(storage);
     });
 
     afterAll(() => {

--- a/src/client/eppo-client-experiment-container.spec.ts
+++ b/src/client/eppo-client-experiment-container.spec.ts
@@ -1,0 +1,85 @@
+import { MOCK_UFC_RESPONSE_FILE, readMockUFCResponse } from '../../test/testHelpers';
+import * as applicationLogger from '../application-logger';
+import { MemoryOnlyConfigurationStore } from '../configuration-store/memory.store';
+import { Flag, ObfuscatedFlag } from '../interfaces';
+
+import EppoClient, { IFlagExperiment } from './eppo-client';
+import { initConfiguration } from './test-utils';
+
+type Container = { name: string };
+
+describe('getExperimentContainer', () => {
+  global.fetch = jest.fn(() => {
+    const ufc = readMockUFCResponse(MOCK_UFC_RESPONSE_FILE);
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(ufc),
+    });
+  }) as jest.Mock;
+
+  const controlContainer: Container = { name: 'Control Container' };
+  const variation1Container: Container = { name: 'Variation 1 Container' };
+  const variation2Container: Container = { name: 'Variation 2 Container' };
+  const variation3Container: Container = { name: 'Variation 3 Container' };
+
+  let client: EppoClient;
+  let flagExperiment: IFlagExperiment<Container>;
+  let getStringAssignmentSpy: jest.SpyInstance;
+  let loggerWarnSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    const storage = new MemoryOnlyConfigurationStore<Flag | ObfuscatedFlag>();
+    await initConfiguration(storage);
+    client = new EppoClient(storage);
+    client.setIsGracefulFailureMode(true);
+    flagExperiment = {
+      flagKey: 'my-key',
+      controlVariation: controlContainer,
+      treatmentVariations: [variation1Container, variation2Container, variation3Container],
+    };
+    getStringAssignmentSpy = jest.spyOn(client, 'getStringAssignment');
+    loggerWarnSpy = jest.spyOn(applicationLogger.logger, 'warn');
+  });
+
+  afterAll(() => {
+    getStringAssignmentSpy.mockRestore();
+    loggerWarnSpy.mockRestore();
+  });
+
+  it('should return the right container when a variation is assigned', async () => {
+    jest.spyOn(client, 'getStringAssignment').mockReturnValue('variation-2');
+    expect(client.getExperimentContainer(flagExperiment, 'subject-key', {})).toEqual(
+      variation2Container,
+    );
+
+    jest.spyOn(client, 'getStringAssignment').mockReturnValue('variation-3');
+    expect(client.getExperimentContainer(flagExperiment, 'subject-key', {})).toEqual(
+      variation3Container,
+    );
+  });
+
+  it('should return the right container when control is assigned', async () => {
+    jest.spyOn(client, 'getStringAssignment').mockReturnValue('control');
+    expect(client.getExperimentContainer(flagExperiment, 'subject-key', {})).toEqual(
+      controlContainer,
+    );
+    expect(loggerWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should default to the control container if an unknown variation is assigned', async () => {
+    jest.spyOn(client, 'getStringAssignment').mockReturnValue('adsfsadfsadf');
+    expect(client.getExperimentContainer(flagExperiment, 'subject-key', {})).toEqual(
+      controlContainer,
+    );
+    expect(loggerWarnSpy).toHaveBeenCalled();
+  });
+
+  it('should default to the control container if an out-of-bounds variation is assigned', async () => {
+    jest.spyOn(client, 'getStringAssignment').mockReturnValue('variation-9');
+    expect(client.getExperimentContainer(flagExperiment, 'subject-key', {})).toEqual(
+      controlContainer,
+    );
+    expect(loggerWarnSpy).toHaveBeenCalled();
+  });
+});

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -2,46 +2,24 @@ import { times } from 'lodash';
 import * as td from 'testdouble';
 
 import {
+  ASSIGNMENT_TEST_DATA_DIR,
   IAssignmentTestCase,
   MOCK_UFC_RESPONSE_FILE,
   OBFUSCATED_MOCK_UFC_RESPONSE_FILE,
   SubjectTestCase,
   getTestAssignments,
   readMockUFCResponse,
-  validateTestAssignments,
   testCasesByFileName,
-  ASSIGNMENT_TEST_DATA_DIR,
+  validateTestAssignments,
 } from '../../test/testHelpers';
-import ApiEndpoints from '../api-endpoints';
 import { IAssignmentLogger } from '../assignment-logger';
-import ConfigurationRequestor from '../configuration-requestor';
 import { IConfigurationStore } from '../configuration-store/configuration-store';
 import { MemoryOnlyConfigurationStore } from '../configuration-store/memory.store';
 import { MAX_EVENT_QUEUE_SIZE, POLL_INTERVAL_MS, POLL_JITTER_PCT } from '../constants';
-import FetchHttpClient from '../http-client';
 import { Flag, ObfuscatedFlag, VariationType } from '../interfaces';
 
 import EppoClient, { FlagConfigurationRequestParameters, checkTypeMatch } from './eppo-client';
-
-export async function init(configurationStore: IConfigurationStore<Flag | ObfuscatedFlag>) {
-  const apiEndpoints = new ApiEndpoints({
-    baseUrl: 'http://127.0.0.1:4000',
-    queryParams: {
-      apiKey: 'dummy',
-      sdkName: 'js-client-sdk-common',
-      sdkVersion: '1.0.0',
-    },
-  });
-  const httpClient = new FetchHttpClient(apiEndpoints, 1000);
-  const configurationRequestor = new ConfigurationRequestor(
-    httpClient,
-    configurationStore,
-    // Leave bandit stores empty for this test
-    null,
-    null,
-  );
-  await configurationRequestor.fetchAndStoreConfigurations();
-}
+import { initConfiguration } from './test-utils';
 
 describe('EppoClient E2E test', () => {
   global.fetch = jest.fn(() => {
@@ -56,7 +34,7 @@ describe('EppoClient E2E test', () => {
   const storage = new MemoryOnlyConfigurationStore<Flag | ObfuscatedFlag>();
 
   beforeAll(async () => {
-    await init(storage);
+    await initConfiguration(storage);
   });
 
   const flagKey = 'mock-flag';
@@ -211,7 +189,7 @@ describe('EppoClient E2E test', () => {
           });
         }) as jest.Mock;
 
-        await init(storage);
+        await initConfiguration(storage);
       });
 
       afterAll(() => {
@@ -260,7 +238,7 @@ describe('EppoClient E2E test', () => {
           });
         }) as jest.Mock;
 
-        await init(storage);
+        await initConfiguration(storage);
       });
 
       afterAll(() => {

--- a/src/client/test-utils.ts
+++ b/src/client/test-utils.ts
@@ -1,0 +1,26 @@
+import ApiEndpoints from '../api-endpoints';
+import ConfigurationRequestor from '../configuration-requestor';
+import { IConfigurationStore } from '../configuration-store/configuration-store';
+import FetchHttpClient from '../http-client';
+import { Flag, ObfuscatedFlag } from '../interfaces';
+
+export async function initConfiguration(
+  configurationStore: IConfigurationStore<Flag | ObfuscatedFlag>,
+) {
+  const apiEndpoints = new ApiEndpoints({
+    baseUrl: 'http://127.0.0.1:4000',
+    queryParams: {
+      apiKey: 'dummy',
+      sdkName: 'js-client-sdk-common',
+      sdkVersion: '1.0.0',
+    },
+  });
+  const httpClient = new FetchHttpClient(apiEndpoints, 1000);
+  const configurationRequestor = new ConfigurationRequestor(
+    httpClient,
+    configurationStore,
+    null,
+    null,
+  );
+  await configurationRequestor.fetchAndStoreConfigurations();
+}


### PR DESCRIPTION
Fixes: [FF-3282](https://linear.app/eppo/issue/FF-3282-contentul-sdk-helper)

## Motivation and Context
This provides a`getExperimentContainer` function for working with content management systems that integrate with Eppo. For instance, the "Eppo" Contentful app will automatically create a new flag with variations "control", "variation-1", "variation-2", etc. The `getExperimentContainer` will map the correct CMS container (e.g. "blog post", "header image", etc) given the string assignment returned.

## How has this been tested?
Unit testing
