### PR TITLE
chore: use latest actions/upload-artifact github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
           access: public
       - name: Upload npm debug log
         if: failure()  # This step will run only if the previous steps failed
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: npm-debug-logs
           path: /home/runner/.npm/_logs/*.log

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk-common",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Eppo SDK for client-side JavaScript applications (base for both web and react native)",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
Fixes upload artifact job and bumps version for new `getExperimentContainer` function

<img width="1457" alt="Screenshot 2024-10-01 at 11 05 10 AM" src="https://github.com/user-attachments/assets/0fda9488-d311-4aae-9172-a3b7007077e1">
